### PR TITLE
Fixed issue when the script tries to acces more cores than the cpu has

### DIFF
--- a/lenovo_fix.py
+++ b/lenovo_fix.py
@@ -38,7 +38,7 @@ power = {'source': None, 'method': 'polling'}
 
 
 def writemsr(msr, val):
-    n = glob.glob('/dev/cpu/[0-9]*/msr')
+    n = glob.glob('/dev/cpu/[0-%d]/msr' % (cpu_count() - 1))
     if not n:
         try:
             subprocess.check_call(('modprobe', 'msr'))


### PR DESCRIPTION
The problem was described in #22 .
Proposed fix is to determine the cpu entries by using the `cpu_count()` function.