### PR TITLE
Fedora: package python3-devel is also required

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sudo systemctl disable thermald.service
 
 ### Fedora
 ```
-dnf install cairo-gobject-devel gobject-introspection-devel dbus-glib-devel python-virtualenv
+dnf install cairo-gobject-devel gobject-introspection-devel dbus-glib-devel python-virtualenv python3-devel
 git clone https://github.com/erpalma/lenovo-throttling-fix.git
 sudo ./install.sh
 ```


### PR DESCRIPTION
To have `./install.sh` run successfully I also needed to install package python3-devel on my Fedora 28 installation.