### PR TITLE
do not overwrite an existing file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ echo "Copying systemd service file..."
 cp systemd/lenovo_fix.service /etc/systemd/system
 
 echo "Building virtualenv..."
-cp requirements.txt lenovo_fix.py mmio.py "$INSTALL_DIR"
+cp -n requirements.txt lenovo_fix.py mmio.py "$INSTALL_DIR"
 cd "$INSTALL_DIR"
 /usr/bin/python3 -m venv venv
 . venv/bin/activate


### PR DESCRIPTION
If the Git repository is checked out to `/opt/lenovo_fix`, the `install.sh` script will fail with the following error:
```
cp: 'requirements.txt' and '/opt/lenovo_fix/requirements.txt' are the same file
cp: 'lenovo_fix.py' and '/opt/lenovo_fix/lenovo_fix.py' are the same file
cp: 'mmio.py' and '/opt/lenovo_fix/mmio.py' are the same file
```
Change the `cp` to `cp -n` will prevent this.