### PR TITLE
GNU Make is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sudo systemctl mask thermald.service
 
 ### Fedora
 ```
-dnf install python3-cairo-devel cairo-gobject-devel gobject-introspection-devel dbus-glib-devel python3-devel
+dnf install python3-cairo-devel cairo-gobject-devel gobject-introspection-devel dbus-glib-devel python3-devel make
 git clone https://github.com/erpalma/lenovo-throttling-fix.git
 sudo ./lenovo-throttling-fix/install.sh
 ```


### PR DESCRIPTION
In default Fedora installation (28/29) GNU make is missing by default. You need to install it before running `install.sh`