### PR TITLE
README: Add P15s Gen 1 to tested hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ On systems where the EC doesn't reset the values (ex: ASUS Zenbook UX430UNR), th
 
 ### Tested hardware
 Other users have confirmed that the tool is also working for these laptops:
-- Lenovo T470s, T480, T480s, X1C5, X1C6, X1C8, T580, L590, L490, L480, T470, X280, ThinkPad Anniversary Edition 25, E590 w/ RX 550X, P43s, E480, E580, T14 Gen 1, P14s Gen 1, T15 Gen 1
+- Lenovo T470s, T480, T480s, X1C5, X1C6, X1C8, T580, L590, L490, L480, T470, X280, ThinkPad Anniversary Edition 25, E590 w/ RX 550X, P43s, E480, E580, T14 Gen 1, P14s Gen 1, T15 Gen 1, P15s Gen 1
 - Dell XPS 9365, 9370, 9550, 7390 2-in-1, Latitude 7390 2-in-1
 - Microsoft Surface Book 2
 - HP Probook 470 G5, Probook 450 G5


### PR DESCRIPTION
Throttled solved the problem of CPU being stuck at 400Mhz under light and moderate load using `acpi` and `intel-pstate` drivers for the Lenovo P15s Gen 1.

Kernels tested:

* 5.4.0-80-generic
* 5.6.0-1018-oem (Ubuntu [certified](https://ubuntu.com/certified/202005-27907) kernel)
* 5.8.0-59-generic
* 5.10.0-1044-oem

Logs can be provided if required.