### PR TITLE
Robustness & correctness fixes: log leak, MSR handling, trip-temp clamp, autoreload, MCHBAR base

### DIFF
--- a/throttled.py
+++ b/throttled.py
@@ -228,20 +228,47 @@ def warning(msg, oneshot=True, end='\n'):
             log_history.add(msg.strip())
 
 
+def get_cpu_list():
+    """Return the sorted CPU indices that expose a /dev/cpu/N entry.
+
+    Returns an empty list when /dev/cpu does not exist yet (msr module not
+    loaded), so callers can decide to load it rather than crashing.
+    """
+    try:
+        entries = os.listdir('/dev/cpu')
+    except FileNotFoundError:
+        return []
+    return sorted(int(x) for x in entries if x.isdigit())
+
+
 def get_msr_list():
     """Return the per-CPU MSR device paths in CPU-index order."""
-    cpus = sorted(int(x) for x in os.listdir('/dev/cpu') if x.isdigit())
-    return [f'/dev/cpu/{cpu:d}/msr' for cpu in cpus]
+    return [f'/dev/cpu/{cpu:d}/msr' for cpu in get_cpu_list()]
 
 
-def writemsr(msr, val):
-    """Write a 64-bit value to the named MSR on every online CPU."""
+def _ensure_msr_module():
+    """Return the per-CPU MSR device list, loading the msr module first if the
+    devices are not present yet. Fatal if they cannot be made to appear.
+
+    Guarding on an empty list matters: without the msr module /dev/cpu may be
+    absent or hold no numeric entries, in which case indexing msr_list[0]
+    would raise IndexError before the modprobe recovery could run.
+    """
     msr_list = get_msr_list()
-    if not os.path.exists(msr_list[0]):
+    if not msr_list or not os.path.exists(msr_list[0]):
         try:
             subprocess.check_call(('modprobe', 'msr'))
         except subprocess.CalledProcessError:
             fatal('Unable to load the msr module.')
+        msr_list = get_msr_list()
+    if not msr_list:
+        fatal('No MSR devices found under /dev/cpu after loading the msr module.')
+    return msr_list
+
+
+def writemsr(msr, val):
+    """Write a 64-bit value to the named MSR on every online CPU."""
+    msr_list = _ensure_msr_module()
     try:
         for addr in msr_list:
             f = os.open(addr, os.O_WRONLY)
@@ -273,12 +300,7 @@ def readmsr(msr, from_bit=0, to_bit=63, cpu=None, flatten=False):
     assert cpu is None or cpu in range(cpu_count())
     if from_bit > to_bit:
         fatal('Wrong readmsr bit params')
-    msr_list = get_msr_list()
-    if not os.path.exists(msr_list[0]):
-        try:
-            subprocess.check_call(('modprobe', 'msr'))
-        except subprocess.CalledProcessError:
-            fatal('Unable to load the msr module.')
+    msr_list = _ensure_msr_module()
     try:
         output = []
         for addr in msr_list:
@@ -293,7 +315,15 @@ def readmsr(msr, from_bit=0, to_bit=63, cpu=None, flatten=False):
             if len(set(output)) > 1:
                 warning(f'Found multiple values for {msr:s} ({MSR_DICT[msr]:x}). This should never happen.')
             return output[0]
-        return output[cpu] if cpu is not None else output
+        if cpu is not None:
+            # output is positional over msr_list; map the CPU *number* to its
+            # slot so a gap in /dev/cpu (offline cores) can't return the wrong
+            # CPU or IndexError.
+            target = f'/dev/cpu/{cpu:d}/msr'
+            if target not in msr_list:
+                fatal(f'CPU {cpu:d} has no MSR device under /dev/cpu.')
+            return output[msr_list.index(target)]
+        return output
     except (IOError, OSError) as e:
         if TESTMSR:
             raise e
@@ -364,10 +394,12 @@ def get_reset_thermal_status():
     """Read IA32_THERM_STATUS for every CPU, then clear the sticky log bits."""
     thermal_status_msr_value = readmsr('IA32_THERM_STATUS')
     thermal_status = []
-    for core in range(cpu_count()):
+    # iterate over the values actually read (one per /dev/cpu entry) rather than
+    # range(cpu_count()): the two can disagree if a core is offline.
+    for msr_value in thermal_status_msr_value:
         thermal_status_core = {}
         for key, value in thermal_status_bits.items():
-            thermal_status_core[key] = int(get_value_for_bits(thermal_status_msr_value[core], value[0], value[1]))
+            thermal_status_core[key] = int(get_value_for_bits(msr_value, value[0], value[1]))
         thermal_status.append(thermal_status_core)
     # reset log bits
     writemsr('IA32_THERM_STATUS', 0)

--- a/throttled.py
+++ b/throttled.py
@@ -749,8 +749,14 @@ def reload_config():
     return config, regs
 
 
-def power_thread(config, regs, exit_event, cpuid):
-    """Daemon main loop: periodically (re-)apply throttling MSRs."""
+def power_thread(state, exit_event, cpuid):
+    """Daemon main loop: periodically (re-)apply throttling MSRs.
+
+    `state` is a shared {'config', 'regs'} dict so that an autoreload here is
+    visible to the D-Bus callbacks in main() too; the local config/regs are
+    kept in sync with it for the rest of the loop.
+    """
+    config, regs = state['config'], state['regs']
     try:
         MCHBAR_BASE = int(check_output(('setpci', '-s', '0:0.0', '48.l')), 16)
     except CalledProcessError:
@@ -784,7 +790,8 @@ def power_thread(config, regs, exit_event, cpuid):
             config_write_time = get_config_write_time()
             if config_write_time and last_config_write_time != config_write_time:
                 last_config_write_time = config_write_time
-                config, regs = reload_config()
+                state['config'], state['regs'] = reload_config()
+                config, regs = state['config'], state['regs']
 
         # switch back to sysfs polling
         if power['method'] == 'polling':
@@ -1040,16 +1047,22 @@ def main():
     set_icc_max(config)
     set_hwp(config.getboolean('AC', 'HWP_Mode', fallback=None))
 
+    # Shared, mutable handle so config/regs updates the power thread makes on
+    # autoreload are seen by the D-Bus callbacks below, which would otherwise
+    # keep applying the config captured at startup (e.g. re-asserting a stale
+    # undervolt offset on resume from sleep after the config was edited).
+    state = {'config': config, 'regs': regs}
+
     exit_event = Event()
-    thread = Thread(target=power_thread, args=(config, regs, exit_event, cpuid))
+    thread = Thread(target=power_thread, args=(state, exit_event, cpuid))
     thread.daemon = True
     thread.start()
 
     # handle dbus events for applying undervolt/IccMax on resume from sleep/hibernate
     def handle_sleep_callback(sleeping):
         if not sleeping:
-            undervolt(config)
-            set_icc_max(config)
+            undervolt(state['config'])
+            set_icc_max(state['config'])
 
     def handle_ac_callback(if_name, changed, invalidated):
         if "OnBattery" in changed:

--- a/throttled.py
+++ b/throttled.py
@@ -749,6 +749,43 @@ def reload_config():
     return config, regs
 
 
+def _read_mchbar_dword(method=None):
+    """Read MCHBAR config register 0x48 of 0:0.0 via setpci, optionally forcing
+    a pcilib access method. Returns the int value, or None on failure."""
+    cmd = ['setpci', '-s', '0:0.0', '48.l']
+    if method:
+        cmd[1:1] = ['-A', method]
+    try:
+        return int(check_output(cmd), 16)
+    except (CalledProcessError, ValueError, FileNotFoundError):
+        # FileNotFoundError = setpci / the pciutils package not installed; it
+        # must not propagate out of the power thread.
+        return None
+
+
+def read_mchbar_base(cpuid):
+    """Return the MCHBAR base address (PCI config 0:0.0 register 0x48).
+
+    Register 0x48 lives past the first 64 config bytes, so setpci's default
+    paths need CAP_SYS_ADMIN (sysfs) or iopl (port I/O). A hardened/sandboxed
+    daemon may have neither, in which case pcilib returns 0xffffffff -- which
+    must not be taken at face value, as it yields an unmappable address and a
+    misleading "/dev/mem" error. The 'ecam' method reads config space via MMIO
+    (/dev/mem, reachable with CAP_SYS_RAWIO), so it still works under such a
+    sandbox; try it first, then the default method, accepting the first value
+    that is neither all-ones/zero nor has the enable bit (bit 0) clear. Only if
+    both fail do we fall back to a per-CPU guess.
+    """
+    for method in ('ecam', None):
+        base = _read_mchbar_dword(method)
+        if base is not None and base not in (0x0, 0xFFFFFFFF) and base & 1:
+            return base
+    warning('Could not read a valid MCHBAR base via setpci (is the pciutils package installed?); guessing from CPUID. This MIGHT NOT WORK!')
+    if cpuid in ((6, 140, 1), (6, 140, 2), (6, 141, 1), (6, 151, 2), (6, 151, 5), (6, 154, 3), (6, 154, 4)):
+        return 0xFEDC0001
+    return 0xFED10001
+
+
 def power_thread(state, exit_event, cpuid):
     """Daemon main loop: periodically (re-)apply throttling MSRs.
 
@@ -757,17 +794,9 @@ def power_thread(state, exit_event, cpuid):
     kept in sync with it for the rest of the loop.
     """
     config, regs = state['config'], state['regs']
+    mchbar_base = read_mchbar_base(cpuid)
     try:
-        MCHBAR_BASE = int(check_output(('setpci', '-s', '0:0.0', '48.l')), 16)
-    except CalledProcessError:
-        warning('Please ensure that "setpci" is in path. This is typically provided by the "pciutils" package.')
-        warning('Trying to guess the MCHBAR address from the CPUID. This MIGHT NOT WORK!')
-        if cpuid in ((6, 140, 1), (6, 140, 2), (6, 141, 1), (6, 151, 2), (6, 151, 5), (6, 154, 3), (6, 154, 4)):
-            MCHBAR_BASE = 0xFEDC0001
-        else:
-            MCHBAR_BASE = 0xFED10001
-    try:
-        mchbar_mmio = MMIO(MCHBAR_BASE + 0x599F, 8)
+        mchbar_mmio = MMIO(mchbar_base + 0x599F, 8)
     except MMIOError:
         warning('Unable to open /dev/mem. TDP override might not work correctly.')
         warning('Try to disable Secure Boot and/or enable CONFIG_DEVMEM in kernel config.')

--- a/throttled.py
+++ b/throttled.py
@@ -205,9 +205,13 @@ def _format(prefix, msg):
 
 def log(msg, oneshot=False, end='\n'):
     outfile = args.log if args.log else sys.stdout
-    if msg.strip() not in log_history or oneshot is False:
+    if not oneshot or msg.strip() not in log_history:
         print(_format('', msg), file=outfile, end=end)
-        log_history.add(msg.strip())
+        # Only oneshot messages are remembered for de-duplication; recording
+        # every line would make log_history grow without bound (e.g. the
+        # ever-changing status line in --monitor mode).
+        if oneshot:
+            log_history.add(msg.strip())
 
 
 def fatal(msg, code=1, end='\n'):
@@ -218,9 +222,10 @@ def fatal(msg, code=1, end='\n'):
 
 def warning(msg, oneshot=True, end='\n'):
     outfile = args.log if args.log else sys.stderr
-    if msg.strip() not in log_history or oneshot is False:
+    if not oneshot or msg.strip() not in log_history:
         print(_format('[W] ', msg), file=outfile, end=end)
-        log_history.add(msg.strip())
+        if oneshot:
+            log_history.add(msg.strip())
 
 
 def get_msr_list():

--- a/throttled.py
+++ b/throttled.py
@@ -632,6 +632,17 @@ def calc_reg_values(platform_info, config):
 
             Trip_Temp_C = config.getfloat(power_source, 'Trip_Temp_C', fallback=None)
             if Trip_Temp_C is not None:
+                # Enforce the >=3C-from-critical ceiling (and the 40C floor) here:
+                # the real range is only known after reading the critical temp, so
+                # load_config()'s earlier clamp against the static [40, 97] range
+                # cannot keep the configured trip below critical-3 on its own.
+                clamped = min(TRIP_TEMP_RANGE[1], max(TRIP_TEMP_RANGE[0], Trip_Temp_C))
+                if clamped != Trip_Temp_C:
+                    log(
+                        f'[!] Overriding "Trip_Temp_C" in "{power_source:s}" to stay within '
+                        f'[{TRIP_TEMP_RANGE[0]:d}, {TRIP_TEMP_RANGE[1]:d}] C: {Trip_Temp_C:.1f} -> {clamped:.1f}'
+                    )
+                    Trip_Temp_C = clamped
                 trip_offset = int(round(critical_temp - Trip_Temp_C))
                 regs[power_source]['MSR_TEMPERATURE_TARGET'] = trip_offset << 24
             else:


### PR DESCRIPTION
Five independent robustness/correctness fixes, each in its own commit. None
change the documented behaviour on a healthy system; they harden edge cases I
ran into while reviewing the daemon on a ThinkPad P53 (Coffee Lake). Each
changed path was exercised by importing the module directly and, for the MCHBAR
one, by reproducing the daemon's exact open/mmap inside a matching systemd
sandbox.

### 1. `log`/`warning`: stop `log_history` growing without bound
`log()`/`warning()` recorded *every* printed message in `log_history`, but that
set is only consulted to de-duplicate `oneshot` messages. Non-oneshot callers —
notably the per-refresh status line in `--monitor`, whose text changes every
iteration — accumulated one entry per call forever. Now only `oneshot=True`
messages are remembered; the print condition is unchanged, so visible output is
identical.

### 2. MSR device-list handling + index by CPU number
- `get_msr_list()[0]` was indexed *before* the `modprobe msr` recovery could
  run. With the msr module not loaded, `/dev/cpu` can be empty or absent, which
  raised `IndexError`/`FileNotFoundError` instead of loading the module.
  Factored into `_ensure_msr_module()`, which guards the empty list, re-reads
  the list after modprobe, and fails cleanly if it stays empty.
- `readmsr(cpu=N)` indexed `output` positionally; it now maps the CPU *number*
  to its slot in `msr_list`, and `get_reset_thermal_status()` iterates the
  values actually read instead of `range(cpu_count())`. Both avoid returning the
  wrong CPU (or `IndexError`) when `/dev/cpu` has gaps from offline cores.

### 3. Actually enforce the 3 °C-from-critical trip-temp ceiling
`calc_reg_values()` tightened `TRIP_TEMP_RANGE[1]` to `critical-3` but never
re-clamped the configured `Trip_Temp_C` against it, so a value between
`critical-3` and the static 97 °C cap (already passed by `load_config()`) was
used verbatim. `Trip_Temp_C` is now clamped to the tightened range before the
offset is derived, logging any override.

### 4. Share config/regs with the D-Bus callbacks on autoreload
`power_thread()` rebinds its local `config`/`regs` on autoreload, but the
`PrepareForSleep` / UPower callbacks defined in `main()` closed over the
original config object loaded at startup. After an autoreload they kept
re-applying the stale undervolt/IccMax on resume from sleep, silently
re-asserting offsets the user had already changed (the loop never re-applies
undervolt, so it persisted until a service restart). A shared
`{'config','regs'}` dict is now passed to `power_thread()` and updated on
reload; the callbacks read the current config from it.

### 5. Validate the setpci-read MCHBAR base, prefer the `ecam` access method
The MCHBAR base lives at PCI config register `0x48`, past the first 64 config
bytes, so setpci's default paths need `CAP_SYS_ADMIN` (sysfs) or `iopl`
(port I/O). A hardened/sandboxed unit — e.g. `CapabilityBoundingSet=` without
`CAP_SYS_ADMIN` and `SystemCallFilter=@system-service` (which drops `iopl`) —
has neither, so `pcilib` hands `setpci` back `0xffffffff`. The old code only
handled setpci *failing* (`CalledProcessError`), not a bogus value, so it
computed an unmappable address (`base + 0x599F`) and surfaced a misleading
`Unable to open /dev/mem` warning while the real cause was the unreadable PCI
config.

`read_mchbar_base()` now tries the `ecam` access method first — it reads config
space via MMIO (`/dev/mem`, reachable with `CAP_SYS_RAWIO`), so it returns the
real base even inside such a sandbox — then the default method, accepting the
first value that is neither all-ones/zero nor has the enable bit (bit 0) clear.
Only if both fail does it fall back to the per-CPU guess. The MCHBAR TDP mirror
then works under the sandbox with no guessing.
