### PR TITLE
Fix MSR field encoding edge cases

### DIFF
--- a/tests/test_msr_encoding.py
+++ b/tests/test_msr_encoding.py
@@ -1,0 +1,68 @@
+import configparser
+import importlib.util
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_throttled():
+    spec = importlib.util.spec_from_file_location('throttled_under_test', ROOT / 'throttled.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.args = SimpleNamespace(log=None, debug=False, config='/tmp/throttled.conf', monitor=None)
+    module.log_history.clear()
+    module.power['source'] = 'AC'
+    module.power['method'] = 'dbus'
+    return module
+
+
+def make_config(sections):
+    config = configparser.ConfigParser()
+    for section, options in sections.items():
+        config.add_section(section)
+        for option, value in options.items():
+            config.set(section, option, str(value))
+    return config
+
+
+class MsrEncodingTests(unittest.TestCase):
+    def test_undervolt_decode_handles_the_sign_boundary(self):
+        throttled = load_throttled()
+
+        for offset_mv in (0, -100, -125, -999, -1000):
+            msr = throttled.calc_undervolt_msr('CORE', offset_mv)
+            self.assertEqual(throttled.calc_undervolt_mv(msr & 0xFFFFFFFF), offset_mv)
+
+    def test_trip_offset_is_clamped_to_the_six_bit_msr_field(self):
+        throttled = load_throttled()
+        config = make_config(
+            {
+                'AC': {'Update_Rate_s': '5', 'Trip_Temp_C': '40'},
+                'BATTERY': {'Update_Rate_s': '30', 'Trip_Temp_C': '40'},
+            }
+        )
+
+        with mock.patch.object(throttled, 'get_critical_temp', return_value=105):
+            with mock.patch.object(throttled, 'log'):
+                regs = throttled.calc_reg_values(
+                    {'feature_programmable_temperature_target': 1, 'feature_programmable_tdp_limit': 0},
+                    config,
+                )
+
+        self.assertEqual(regs['AC']['MSR_TEMPERATURE_TARGET'], 63 << 24)
+        self.assertEqual(regs['BATTERY']['MSR_TEMPERATURE_TARGET'], 63 << 24)
+
+    def test_icc_max_encoder_rejects_values_that_overflow_ten_bits(self):
+        throttled = load_throttled()
+
+        self.assertEqual(throttled.calc_icc_max_msr('CORE', 0x3FF / 4) & 0x3FF, 0x3FF)
+        with self.assertRaises(AssertionError):
+            throttled.calc_icc_max_msr('CORE', 256)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/throttled.py
+++ b/throttled.py
@@ -532,7 +532,8 @@ def calc_undervolt_msr(plane, offset):
 def calc_undervolt_mv(msr_value):
     """Return the offset voltage (in mV) from the given raw MSR 150h value."""
     offset = (msr_value & 0xFFE00000) >> 21
-    offset = offset if offset <= 0x400 else -(0x800 - offset)
+    # 11-bit two's complement: values >= 0x400 are negative
+    offset = offset if offset < 0x400 else -(0x800 - offset)
     return int(round(offset / 1.024))
 
 
@@ -573,7 +574,8 @@ def calc_icc_max_msr(plane, current):
     """Return the value to be written in the MSR 150h for setting the given
     IccMax (in A) to the given current plane.
     """
-    assert 0 < current <= 0x3FF
+    # the MSR field is 10 bits of 1/4 A steps: max 0x3FF / 4 = 255.75 A
+    assert 0 < current <= 0x3FF / 4
     assert plane in CURRENT_PLANES
     current = int(round(current * 4))
     return 0x8000001700000000 | (CURRENT_PLANES[plane] << 40) | current
@@ -738,6 +740,14 @@ def calc_reg_values(platform_info, config):
                     )
                     Trip_Temp_C = valid_trip_temp
                 trip_offset = int(round(critical_temp - Trip_Temp_C))
+                if trip_offset > 63:
+                    # the offset field is 6 bits wide: a larger value would
+                    # spill into adjacent bits and corrupt the register
+                    log(
+                        f'[!] Overriding "Trip_Temp_C" in "{power_source:s}": offset {trip_offset:d} '
+                        f'exceeds the 6-bit MSR field, clamping to {critical_temp - 63:d} C'
+                    )
+                    trip_offset = 63
                 regs[power_source]['MSR_TEMPERATURE_TARGET'] = trip_offset << 24
             else:
                 log(f'[I] {power_source:s} trip temperature is disabled in config.')


### PR DESCRIPTION
Three independent bugs in the low-level MSR encode/decode helpers, found during an automated audit of the codebase and each covered by a new test in `tests/test_msr_encoding.py`:

1. **`calc_undervolt_mv()` sign boundary off by one** — the 11-bit undervolt field is two's complement over `[0x000, 0x7FF]`: `0x400` is the most-negative value (−512 steps), not a positive one. The old `offset <= 0x400` decoded it as +512. Now `< 0x400`, and encode→decode round-trips at the boundary.

2. **Trip-temperature offset overflows its 6-bit field** — `MSR_TEMPERATURE_TARGET` stores the offset in bits 24–29. A `Trip_Temp_C` far below the critical temperature produced an offset > 63 that silently spilled into adjacent bits. Now clamped to 63 with a log line stating the effective temperature.

3. **`calc_icc_max_msr()` accepted values that truncate** — the IccMax field is 10 bits of quarter-amp steps, so the representable maximum is `0x3FF / 4` = 255.75 A, not 0x3FF A. The old assertion let values up to 1023 A through to a silent truncation on write.

Tests: `python -m pytest tests/` is green (27 passed) with the new file included.

Note: this is one of four small thematic PRs from the same audit (see also the daemon-robustness, power-source-flip and config-validation PRs); they are independent against master and any cross-conflicts on merge are trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
