### PR TITLE
Exit loudly when the power thread dies (no more zombie daemon)

### DIFF
--- a/systemd/throttled.service
+++ b/systemd/throttled.service
@@ -1,11 +1,14 @@
 [Unit]
-Description=Stop Intel throttling 
+Description=Stop Intel throttling
 
 [Service]
 Type=simple
 ExecStart=/opt/throttled/venv/bin/python3 /opt/throttled/throttled.py
 # Setting PYTHONUNBUFFERED is necessary to see the output of this service in the journal
 Environment=PYTHONUNBUFFERED=1
+# The daemon exits non-zero if the power thread dies: let systemd revive it
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test_daemon_robustness.py
+++ b/tests/test_daemon_robustness.py
@@ -1,0 +1,66 @@
+import importlib.util
+import io
+import unittest
+from pathlib import Path
+from threading import Thread
+from types import SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_throttled():
+    spec = importlib.util.spec_from_file_location('throttled_under_test', ROOT / 'throttled.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.args = SimpleNamespace(log=None, debug=False, config='/tmp/throttled.conf', monitor=None)
+    module.log_history.clear()
+    module.power['source'] = 'AC'
+    module.power['method'] = 'dbus'
+    return module
+
+
+class StopAfterWait:
+    def __init__(self):
+        self.stopped = False
+
+    def is_set(self):
+        return self.stopped
+
+    def wait(self, timeout):
+        self.stopped = True
+
+
+class DaemonRobustnessTests(unittest.TestCase):
+    def test_fatal_in_a_worker_thread_kills_the_whole_process(self):
+        throttled = load_throttled()
+
+        def run_fatal():
+            try:
+                throttled.fatal('boom')
+            except SystemExit:
+                # reached only because os._exit is mocked out below
+                pass
+
+        with mock.patch.object(throttled.os, '_exit') as os_exit:
+            with mock.patch('sys.stderr', new=io.StringIO()):
+                thread = Thread(target=run_fatal)
+                thread.start()
+                thread.join()
+
+        os_exit.assert_called_once_with(1)
+
+    def test_power_thread_crash_exits_the_process_for_systemd_to_restart(self):
+        throttled = load_throttled()
+
+        with mock.patch.object(throttled, '_power_thread', side_effect=RuntimeError('boom')):
+            with mock.patch.object(throttled.os, '_exit') as os_exit:
+                with mock.patch.object(throttled, 'warning'):
+                    throttled.power_thread({}, None, None)
+
+        os_exit.assert_called_once_with(1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/throttled.py
+++ b/throttled.py
@@ -9,12 +9,13 @@ import re
 import struct
 import subprocess
 import sys
+import traceback
 from collections import defaultdict
 from datetime import datetime
 from errno import EACCES, EIO, EPERM
 from platform import uname
 from subprocess import check_output, CalledProcessError
-from threading import Event, Thread
+from threading import Event, Thread, current_thread, main_thread
 from time import time
 
 from mmio import MMIO, MMIOError
@@ -222,6 +223,11 @@ def log(msg, oneshot=False, end='\n'):
 def fatal(msg, code=1, end='\n'):
     outfile = args.log if args.log else sys.stderr
     print(_format('[E] ', msg), file=outfile, end=end)
+    if current_thread() is not main_thread():
+        # sys.exit() would only kill the calling thread, leaving a zombie
+        # daemon that looks healthy to systemd but no longer touches MSRs
+        outfile.flush()
+        os._exit(code)
     sys.exit(code)
 
 
@@ -870,6 +876,20 @@ def read_mchbar_base(cpuid):
 
 
 def power_thread(state, exit_event, cpuid):
+    """Crash-loud wrapper for _power_thread: an uncaught exception (or a
+    sys.exit() from a helper) would only kill this thread, leaving a zombie
+    daemon that looks healthy to systemd while no longer touching the hardware.
+    """
+    try:
+        _power_thread(state, exit_event, cpuid)
+    except Exception:
+        warning(f'power thread crashed:\n{traceback.format_exc()}', oneshot=False)
+        if args.log:
+            args.log.flush()
+        os._exit(1)
+
+
+def _power_thread(state, exit_event, cpuid):
     """Daemon main loop: periodically (re-)apply throttling MSRs."""
     config, regs = state['config'], state['regs']
     mchbar_base = read_mchbar_base(cpuid)


### PR DESCRIPTION
When the power thread dies (uncaught exception, or a helper calling `sys.exit()` which only unwinds the calling thread), the main process stays alive: systemd sees a healthy service while no MSR or MMIO register is being written anymore — a silent zombie that stops enforcing the configured limits.

Two complementary fixes plus the unit change to make them actionable:

- **`fatal()` from a worker thread now calls `os._exit()`** instead of `sys.exit()`, terminating the whole process so systemd can see the failure.
- **`power_thread()` becomes a crash-loud wrapper around `_power_thread()`**: any unhandled exception is logged with a full traceback (and the log file flushed) before `os._exit(1)`, so the journal always contains the root cause.
- **`systemd/throttled.service` gains `Restart=on-failure` / `RestartSec=5`** so the daemon is revived automatically after either failure mode.

Both failure paths are covered by tests in `tests/test_daemon_robustness.py`; `python -m pytest tests/` is green (26 passed).

Note: this is one of four small thematic PRs from the same audit; they are independent against master and any cross-conflicts on merge are trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
