### PR TITLE
Re-apply undervolt and IccMax on power source changes

### DIFF
--- a/tests/test_power_source_flip.py
+++ b/tests/test_power_source_flip.py
@@ -1,0 +1,89 @@
+import configparser
+import importlib.util
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_throttled():
+    spec = importlib.util.spec_from_file_location('throttled_under_test', ROOT / 'throttled.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.args = SimpleNamespace(log=None, debug=False, config='/tmp/throttled.conf', monitor=None)
+    module.log_history.clear()
+    module.power['source'] = 'AC'
+    module.power['method'] = 'dbus'
+    return module
+
+
+def make_config(sections):
+    config = configparser.ConfigParser()
+    for section, options in sections.items():
+        config.add_section(section)
+        for option, value in options.items():
+            config.set(section, option, str(value))
+    return config
+
+
+class StopAfterWait:
+    def __init__(self):
+        self.stopped = False
+
+    def is_set(self):
+        return self.stopped
+
+    def wait(self, timeout):
+        self.stopped = True
+
+
+class PowerSourceFlipTests(unittest.TestCase):
+    def test_resume_listener_checks_the_planes_each_key_actually_supports(self):
+        throttled = load_throttled()
+
+        self.assertFalse(throttled.should_listen_for_resume(make_config({'ICCMAX.AC': {'UNCORE': 200}})))
+        self.assertTrue(throttled.should_listen_for_resume(make_config({'ICCMAX.AC': {'CORE': 200}})))
+        self.assertTrue(throttled.should_listen_for_resume(make_config({'UNDERVOLT.AC': {'ANALOGIO': -50}})))
+
+    def test_set_icc_max_honors_an_explicit_power_source(self):
+        throttled = load_throttled()
+        throttled.power['source'] = 'BATTERY'
+        config = make_config({'ICCMAX.AC': {'CORE': 100}})
+
+        with mock.patch.object(throttled, 'writemsr') as writemsr:
+            with mock.patch.object(throttled, 'warning'):
+                throttled.set_icc_max(config, source='AC')
+
+        writemsr.assert_called_once_with('MSR_OC_MAILBOX', throttled.calc_icc_max_msr('CORE', 100))
+
+    def test_power_flip_reapplies_undervolt_and_iccmax(self):
+        throttled = load_throttled()
+        throttled.power['source'] = 'BATTERY'
+        throttled.power['method'] = 'polling'
+        config = make_config(
+            {
+                'GENERAL': {'Autoreload': 'False'},
+                'AC': {'Update_Rate_s': '5'},
+                'BATTERY': {'Update_Rate_s': '30'},
+            }
+        )
+        state = {'config': config, 'regs': {'AC': {}, 'BATTERY': {}}}
+        calls = []
+
+        with mock.patch.object(throttled, 'read_mchbar_base', return_value=0):
+            with mock.patch.object(throttled, 'MMIO'):
+                with mock.patch.object(throttled, 'is_on_battery', return_value=False):
+                    with mock.patch.object(throttled, 'undervolt', lambda config, source=None: calls.append(('undervolt', source))):
+                        with mock.patch.object(throttled, 'set_icc_max', lambda config, source=None: calls.append(('iccmax', source))):
+                            with mock.patch.object(throttled, 'log'):
+                                throttled.power_thread(state, StopAfterWait(), None)
+
+        self.assertEqual(calls, [('undervolt', 'AC'), ('iccmax', 'AC')])
+        self.assertEqual(throttled.power['source'], 'AC')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/throttled.py
+++ b/throttled.py
@@ -418,7 +418,10 @@ def handle_ac_properties_changed(if_name, changed, invalidated):
 
 def should_listen_for_resume(config):
     return any(
-        config.getfloat(key, plane, fallback=0) != 0 for plane in VOLTAGE_PLANES for key in UNDERVOLT_KEYS + ICCMAX_KEYS
+        config.getfloat(key, plane, fallback=0) != 0
+        for keys, planes in ((UNDERVOLT_KEYS, VOLTAGE_PLANES), (ICCMAX_KEYS, CURRENT_PLANES))
+        for key in keys
+        for plane in planes
     )
 
 
@@ -550,9 +553,10 @@ def get_undervolt(plane=None, convert=False):
     return out
 
 
-def undervolt(config):
+def undervolt(config, source=None):
     """Apply the undervolt offsets from the config to all voltage planes."""
-    section = f"UNDERVOLT.{power['source']}"
+    source = source or power['source']
+    section = f'UNDERVOLT.{source}'
     if (section not in config and 'UNDERVOLT' not in config) or 'UNDERVOLT' in UNSUPPORTED_FEATURES:
         return
     for plane in VOLTAGE_PLANES:
@@ -615,9 +619,10 @@ def get_icc_max(plane=None, convert=False):
     return out
 
 
-def set_icc_max(config):
+def set_icc_max(config, source=None):
     """Apply the IccMax limits from the config to all current planes."""
-    section = f"ICCMAX.{power['source']}"
+    source = source or power['source']
+    section = f'ICCMAX.{source}'
     for plane in CURRENT_PLANES:
         try:
             write_current_amp = config.getfloat(
@@ -881,6 +886,7 @@ def power_thread(state, exit_event, cpuid):
         mchbar_mmio = None
 
     next_hwp_write = 0
+    applied_source = power['source']
     last_config_write_time = (
         get_config_write_time() if config.getboolean('GENERAL', 'Autoreload', fallback=False) else None
     )
@@ -904,9 +910,26 @@ def power_thread(state, exit_event, cpuid):
         if power['method'] == 'polling':
             power['source'] = 'BATTERY' if is_on_battery(config) else 'AC'
 
+        # snapshot the power source once per iteration: the D-Bus callback can
+        # flip it concurrently and every write below must agree on one profile
+        power_source = power['source']
+
+        # re-apply the one-shot per-profile settings when the power source flips
+        if power_source != applied_source:
+            log(f'[I] Power source changed: {applied_source:s} -> {power_source:s}')
+            undervolt(config, source=power_source)
+            set_icc_max(config, source=power_source)
+            if config.getboolean('AC', 'HWP_Mode', fallback=False):
+                if power_source == 'AC':
+                    next_hwp_write = 0
+                else:
+                    # restore the default energy/performance preference on battery
+                    set_hwp(False)
+            applied_source = power_source
+
         # set temperature trip point
-        if 'MSR_TEMPERATURE_TARGET' in regs[power['source']]:
-            write_value = regs[power['source']]['MSR_TEMPERATURE_TARGET']
+        if 'MSR_TEMPERATURE_TARGET' in regs[power_source]:
+            write_value = regs[power_source]['MSR_TEMPERATURE_TARGET']
             writemsr('MSR_TEMPERATURE_TARGET', write_value)
             if args.debug:
                 read_value = readmsr('MSR_TEMPERATURE_TARGET', 24, 29, flatten=True)
@@ -914,8 +937,8 @@ def power_thread(state, exit_event, cpuid):
                 log(f'[D] TEMPERATURE_TARGET - write {write_value >> 24:#x} - read {read_value:#x} - match {match}')
 
         # set cTDP
-        if 'MSR_CONFIG_TDP_CONTROL' in regs[power['source']]:
-            write_value = regs[power['source']]['MSR_CONFIG_TDP_CONTROL']
+        if 'MSR_CONFIG_TDP_CONTROL' in regs[power_source]:
+            write_value = regs[power_source]['MSR_CONFIG_TDP_CONTROL']
             writemsr('MSR_CONFIG_TDP_CONTROL', write_value)
             if args.debug:
                 read_value = readmsr('MSR_CONFIG_TDP_CONTROL', 0, 1, flatten=True)
@@ -923,8 +946,8 @@ def power_thread(state, exit_event, cpuid):
                 log(f'[D] CONFIG_TDP_CONTROL - write {write_value:#x} - read {read_value:#x} - match {match}')
 
         # set PL1/2 on MSR
-        if 'MSR_PKG_POWER_LIMIT' in regs[power['source']]:
-            write_value = regs[power['source']]['MSR_PKG_POWER_LIMIT']
+        if 'MSR_PKG_POWER_LIMIT' in regs[power_source]:
+            write_value = regs[power_source]['MSR_PKG_POWER_LIMIT']
             writemsr('MSR_PKG_POWER_LIMIT', write_value)
             if args.debug:
                 read_value = readmsr('MSR_PKG_POWER_LIMIT', 0, 55, flatten=True)
@@ -941,14 +964,14 @@ def power_thread(state, exit_event, cpuid):
                     )
 
         # Disable BDPROCHOT
-        disable_bdprochot = config.getboolean(power['source'], 'Disable_BDPROCHOT', fallback=None)
+        disable_bdprochot = config.getboolean(power_source, 'Disable_BDPROCHOT', fallback=None)
         if disable_bdprochot:
             set_disable_bdprochot()
 
-        wait_t = get_update_rate(config, power['source'])
+        wait_t = get_update_rate(config, power_source)
         enable_hwp_mode = config.getboolean('AC', 'HWP_Mode', fallback=None)
         # set HWP less frequently. Just to be safe since (e.g.) TLP might reset this value
-        if enable_hwp_mode and next_hwp_write <= time() and power['source'] == 'AC':
+        if enable_hwp_mode and next_hwp_write <= time() and power_source == 'AC':
             set_hwp(enable_hwp_mode)
             next_hwp_write = time() + HWP_INTERVAL
 


### PR DESCRIPTION
Undervolt offsets and IccMax limits are effectively one-shot: they were applied at startup for the then-active power profile and never again. Transitioning between AC and battery left the previous profile's values active indefinitely (e.g. the aggressive AC undervolt kept running on battery, or vice versa).

Changes:

- **`undervolt()` and `set_icc_max()` take an explicit `source` parameter** so callers can target a specific profile instead of racing on the global `power['source']`.
- **The power loop snapshots `power['source']` once per iteration** — the D-Bus callback can flip it concurrently, and every register write in one iteration must agree on a single profile.
- **On a profile change the loop immediately re-applies** undervolt and IccMax for the new profile, and (when `HWP_Mode` is set) forces an immediate HWP write on AC or restores the default preference on battery.
- **`should_listen_for_resume()` now pairs each key set with its own plane set** (`UNDERVOLT_KEYS`×`VOLTAGE_PLANES`, `ICCMAX_KEYS`×`CURRENT_PLANES`) instead of crossing all keys over voltage planes only — an `[ICCMAX]` config with only non-voltage planes set was previously invisible to the resume listener.

Covered by `tests/test_power_source_flip.py`; `python -m pytest tests/` is green (27 passed).

Note: this is one of four small thematic PRs from the same audit; they are independent against master and any cross-conflicts on merge are trivial (this PR and the config-validation one touch different lines of `set_icc_max()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
