### PR TITLE
Reject unencodable undervolt offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ valid configuration changes automatically when `Autoreload` is enabled.
 ### Undervolting and IccMax
 
 Voltage offsets can be configured independently in `[UNDERVOLT.AC]` and
-`[UNDERVOLT.BATTERY]`. Only zero or negative millivolt values are accepted.
+`[UNDERVOLT.BATTERY]`. Only zero or negative millivolt values down to -1000 mV
+are accepted (the hardware field is signed 11-bit); anything below is rejected.
 Start at zero and test small changes under load; values stable on one CPU can
 crash another CPU of the same model.
 

--- a/etc/throttled.conf
+++ b/etc/throttled.conf
@@ -47,7 +47,7 @@ cTDP: 0
 # Disable BDPROCHOT (EXPERIMENTAL)
 Disable_BDPROCHOT: False
 
-# All voltage values are expressed in mV and *MUST* be negative (i.e. undervolt)! 
+# All voltage values are expressed in mV and *MUST* be negative (i.e. undervolt), not below -1000 mV!
 [UNDERVOLT.BATTERY]
 # CPU core voltage offset (mV)
 CORE: 0
@@ -60,7 +60,7 @@ UNCORE: 0
 # Analog I/O voltage offset (mV)
 ANALOGIO: 0
 
-# All voltage values are expressed in mV and *MUST* be negative (i.e. undervolt)!
+# All voltage values are expressed in mV and *MUST* be negative (i.e. undervolt), not below -1000 mV!
 [UNDERVOLT.AC]
 # CPU core voltage offset (mV)
 CORE: 0

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -53,6 +53,23 @@ class ConfigValidationTests(unittest.TestCase):
         self.assertEqual(config.getfloat('UNDERVOLT', 'CORE'), -50)
         self.assertEqual(config.getfloat('UNDERVOLT', 'CACHE', fallback=0.0), 0.0)
 
+    def test_load_config_removes_unencodable_undervolt_values(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[GENERAL]\nEnabled: True\n'
+            '[AC]\nUpdate_Rate_s: 5\n'
+            '[UNDERVOLT]\nCORE: -1001\nCACHE: -1000\nGPU: nan\nUNCORE: -inf\nANALOGIO: 1\n'
+        )
+
+        with mock.patch.object(throttled, 'warning'):
+            config = throttled.load_config()
+
+        self.assertFalse(config.has_option('UNDERVOLT', 'CORE'))
+        self.assertEqual(config.getfloat('UNDERVOLT', 'CACHE'), -1000)
+        self.assertFalse(config.has_option('UNDERVOLT', 'GPU'))
+        self.assertFalse(config.has_option('UNDERVOLT', 'UNCORE'))
+        self.assertEqual(config.getfloat('UNDERVOLT', 'ANALOGIO'), 0)
+
     def test_load_config_rejects_iccmax_values_that_overflow_the_field(self):
         throttled = load_throttled()
         throttled.args.config = self.write_config(

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -61,7 +61,7 @@ class ConfigValidationTests(unittest.TestCase):
             '[UNDERVOLT]\nCORE: -1001\nCACHE: -1000\nGPU: nan\nUNCORE: -inf\nANALOGIO: 1\n'
         )
 
-        with mock.patch.object(throttled, 'warning'):
+        with mock.patch.object(throttled, 'warning'), mock.patch.object(throttled, 'log'):
             config = throttled.load_config()
 
         self.assertFalse(config.has_option('UNDERVOLT', 'CORE'))

--- a/tests/test_msr_encoding.py
+++ b/tests/test_msr_encoding.py
@@ -37,6 +37,18 @@ class MsrEncodingTests(unittest.TestCase):
             msr = throttled.calc_undervolt_msr('CORE', offset_mv)
             self.assertEqual(throttled.calc_undervolt_mv(msr & 0xFFFFFFFF), offset_mv)
 
+    def test_undervolt_encoder_rejects_values_outside_signed_eleven_bits(self):
+        throttled = load_throttled()
+
+        with self.assertRaisesRegex(ValueError, 'between -1000 and 0 mV'):
+            throttled.calc_undervolt_msr('CORE', -1001)
+        with self.assertRaisesRegex(ValueError, 'between -1000 and 0 mV'):
+            throttled.calc_undervolt_msr('CORE', 1)
+        for invalid in (float('nan'), float('inf'), float('-inf')):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ValueError, 'between -1000 and 0 mV'):
+                    throttled.calc_undervolt_msr('CORE', invalid)
+
     def test_trip_offset_is_clamped_to_the_six_bit_msr_field(self):
         throttled = load_throttled()
         config = make_config(

--- a/throttled.py
+++ b/throttled.py
@@ -4,6 +4,7 @@ import asyncio
 import configparser
 import glob
 import gzip
+import math
 import os
 import re
 import struct
@@ -54,6 +55,9 @@ MSR_DICT = {
 HWP_PERFORMANCE_VALUE = 0x20
 HWP_DEFAULT_VALUE = 0x80
 HWP_INTERVAL = 60
+UNDERVOLT_TICKS_PER_MV = 1.024
+UNDERVOLT_MIN_TICKS = -(1 << 10)
+UNDERVOLT_MAX_TICKS = 0
 
 
 platform_info_bits = {
@@ -532,15 +536,30 @@ def calc_time_window_vars(t):
     raise ValueError('Unable to find a good combination!')
 
 
+def _undervolt_offset_to_ticks(offset):
+    """Convert an undervolt in mV to the signed 11-bit mailbox field."""
+    try:
+        offset = float(offset)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f'Undervolt offset must be a number, got {offset!r}.') from e
+    minimum_mv = UNDERVOLT_MIN_TICKS / UNDERVOLT_TICKS_PER_MV
+    if not math.isfinite(offset) or not minimum_mv <= offset <= 0:
+        raise ValueError(f'Undervolt offset must be between {minimum_mv:g} and 0 mV, got {offset!r}.')
+    ticks = int(round(offset * UNDERVOLT_TICKS_PER_MV))
+    if not UNDERVOLT_MIN_TICKS <= ticks <= UNDERVOLT_MAX_TICKS:
+        raise ValueError(f'Undervolt offset {offset!r} mV does not fit the signed 11-bit mailbox field.')
+    return ticks
+
+
 def calc_undervolt_msr(plane, offset):
     """Return the value to be written in the MSR 150h for setting the given
     offset voltage (in mV) to the given voltage plane.
     """
-    assert offset <= 0
-    assert plane in VOLTAGE_PLANES
-    offset = int(round(offset * 1.024))
-    offset = 0xFFE00000 & ((offset & 0xFFF) << 21)
-    return 0x8000001100000000 | (VOLTAGE_PLANES[plane] << 40) | offset
+    if plane not in VOLTAGE_PLANES:
+        raise ValueError(f'Unknown voltage plane: {plane!r}.')
+    ticks = _undervolt_offset_to_ticks(offset)
+    encoded_offset = (ticks & 0x7FF) << 21
+    return 0x8000001100000000 | (VOLTAGE_PLANES[plane] << 40) | encoded_offset
 
 
 def calc_undervolt_mv(msr_value):
@@ -548,7 +567,7 @@ def calc_undervolt_mv(msr_value):
     offset = (msr_value & 0xFFE00000) >> 21
     # 11-bit two's complement: values >= 0x400 are negative
     offset = offset if offset < 0x400 else -(0x800 - offset)
-    return int(round(offset / 1.024))
+    return int(round(offset / UNDERVOLT_TICKS_PER_MV))
 
 
 def get_undervolt(plane=None, convert=False):
@@ -687,17 +706,26 @@ def load_config():
                     f'[!] Overriding invalid "Trip_Temp_C" value in "{power_source:s}": {trip_temp:.1f} -> {valid_trip_temp:.1f}'
                 )
 
-    # fix any invalid value (ie. > 0) in the undervolt settings
+    # Validate the signed 11-bit undervolt field before any mailbox write.
+    # Positive offsets retain the historical behavior of being forced to zero;
+    # values below the representable minimum are removed instead of wrapping.
     for key in UNDERVOLT_KEYS:
         for plane in VOLTAGE_PLANES:
             if key in config:
-                value = config.getfloat(key, plane, fallback=0.0)
-                valid_value = min(0, value)
-                if value != valid_value:
-                    config.set(key, plane, str(valid_value))
-                    log(
-                        f'[!] Overriding invalid "{key:s}" value in "{plane:s}" voltage plane: {value:.0f} -> {valid_value:.0f}'
-                    )
+                try:
+                    value = config.getfloat(key, plane, fallback=0.0)
+                    if not math.isfinite(value):
+                        raise ValueError(f'Undervolt offset must be finite, got {value!r}.')
+                    if value > 0:
+                        config.set(key, plane, '0')
+                        log(
+                            f'[!] Overriding invalid "{key:s}" value in "{plane:s}" voltage plane: ' f'{value:.0f} -> 0'
+                        )
+                    else:
+                        _undervolt_offset_to_ticks(value)
+                except ValueError as e:
+                    warning(f'Invalid value for {plane:s} in {key:s}: {e}', oneshot=False)
+                    config.remove_option(key, plane)
 
     # handle the case where only one of UNDERVOLT.AC, UNDERVOLT.BATTERY keys exists
     # by forcing the other key to all zeros (ie. no undervolt)

--- a/throttled.py
+++ b/throttled.py
@@ -706,9 +706,7 @@ def load_config():
                     f'[!] Overriding invalid "Trip_Temp_C" value in "{power_source:s}": {trip_temp:.1f} -> {valid_trip_temp:.1f}'
                 )
 
-    # Validate the signed 11-bit undervolt field before any mailbox write.
-    # Positive offsets retain the historical behavior of being forced to zero;
-    # values below the representable minimum are removed instead of wrapping.
+    # the mailbox field is signed 11-bit: reject anything below -1000 mV instead of wrapping it positive
     for key in UNDERVOLT_KEYS:
         for plane in VOLTAGE_PLANES:
             if key in config:
@@ -719,7 +717,7 @@ def load_config():
                     if value > 0:
                         config.set(key, plane, '0')
                         log(
-                            f'[!] Overriding invalid "{key:s}" value in "{plane:s}" voltage plane: ' f'{value:.0f} -> 0'
+                            f'[!] Overriding invalid "{key:s}" value in "{plane:s}" voltage plane: {value:.0f} -> 0'
                         )
                     else:
                         _undervolt_offset_to_ticks(value)


### PR DESCRIPTION
## Summary

- validate undervolt offsets against the signed 11-bit mailbox field before encoding
- reject values below `-1000 mV` and non-finite values before they can reach an MSR write
- positive offsets keep the historical clamp to zero; below-range values are removed from the config, matching the ICCMAX loop's convention — happy to switch to clamping at `-1000` if you prefer

## Root cause

The encoder rounded the millivolt offset and masked it into the mailbox field without checking the lower bound: `-1001 mV` became tick `-1025`, and masking to 11 bits produced `0x3ff`, which decodes as roughly `+999 mV` — an overvolt. The previous upper-bound check was an `assert`, so it disappears under `python -O`.

## Tests

- full unittest suite on Python 3.10–3.14; the undervolt encoder and config-validation tests also pass under `python -O`
- `git diff --check` clean

Prepared with assistance from OpenAI Codex.
