### PR TITLE
Preserve per-CPU HWP request fields

### DIFF
--- a/tests/test_hwp_per_cpu.py
+++ b/tests/test_hwp_per_cpu.py
@@ -1,0 +1,134 @@
+import importlib.util
+import io
+import errno
+import struct
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_throttled():
+    spec = importlib.util.spec_from_file_location('throttled_under_test', ROOT / 'throttled.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.args = SimpleNamespace(log=None, debug=False, config='/tmp/throttled.conf', force=True, monitor=None)
+    module.log_history.clear()
+    module.power['source'] = 'AC'
+    module.power['method'] = 'dbus'
+    return module
+
+
+class HWPPerCpuTests(unittest.TestCase):
+    def test_set_hwp_rewrites_each_cpu_independently(self):
+        throttled = load_throttled()
+        current = {
+            0: 0xAAAABBBB01020304,
+            2: 0x1111222233445566,
+        }
+
+        def readmsr(msr, *args, cpu=None, **kwargs):
+            self.assertEqual(msr, 'IA32_HWP_REQUEST')
+            return current[cpu]
+
+        with mock.patch.object(throttled, '_ensure_msr_module', return_value=['/dev/cpu/0/msr', '/dev/cpu/2/msr']):
+            with mock.patch.object(throttled, 'readmsr', side_effect=readmsr):
+                with mock.patch.object(throttled, 'writemsr') as writemsr:
+                    throttled.set_hwp(True)
+
+        expected = [
+            mock.call(
+                'IA32_HWP_REQUEST',
+                (current[0] & 0xFFFFFFFF00FFFFFF) | (throttled.HWP_PERFORMANCE_VALUE << 24),
+                cpu=0,
+            ),
+            mock.call(
+                'IA32_HWP_REQUEST',
+                (current[2] & 0xFFFFFFFF00FFFFFF) | (throttled.HWP_PERFORMANCE_VALUE << 24),
+                cpu=2,
+            ),
+        ]
+        self.assertEqual(writemsr.call_args_list, expected)
+
+    def test_writemsr_cpu_targets_one_msr_device(self):
+        throttled = load_throttled()
+
+        with mock.patch.object(throttled, '_ensure_msr_module', return_value='/dev/cpu/2/msr') as ensure:
+            with mock.patch.object(throttled.os, 'open', return_value=11) as open_:
+                with mock.patch.object(throttled.os, 'lseek') as lseek:
+                    with mock.patch.object(throttled.os, 'write') as write:
+                        with mock.patch.object(throttled.os, 'close') as close:
+                            throttled.writemsr('IA32_HWP_REQUEST', 0x1234, cpu=2)
+
+        ensure.assert_called_once_with(2)
+        open_.assert_called_once_with('/dev/cpu/2/msr', throttled.os.O_WRONLY)
+        lseek.assert_called_once_with(11, throttled.MSR_DICT['IA32_HWP_REQUEST'], throttled.os.SEEK_SET)
+        write.assert_called_once_with(11, struct.pack('Q', 0x1234))
+        close.assert_called_once_with(11)
+
+    def test_writemsr_without_cpu_preserves_broadcast(self):
+        throttled = load_throttled()
+
+        with mock.patch.object(
+            throttled, '_ensure_msr_module', return_value=['/dev/cpu/0/msr', '/dev/cpu/2/msr']
+        ) as ensure:
+            with mock.patch.object(throttled.os, 'open', side_effect=[10, 20]) as open_:
+                with mock.patch.object(throttled.os, 'lseek'):
+                    with mock.patch.object(throttled.os, 'write'):
+                        with mock.patch.object(throttled.os, 'close'):
+                            throttled.writemsr('IA32_HWP_REQUEST', 0x1234)
+
+        ensure.assert_called_once_with()
+        self.assertEqual(
+            open_.call_args_list,
+            [
+                mock.call('/dev/cpu/0/msr', throttled.os.O_WRONLY),
+                mock.call('/dev/cpu/2/msr', throttled.os.O_WRONLY),
+            ],
+        )
+
+    def test_writemsr_rejects_invalid_cpu_arguments(self):
+        throttled = load_throttled()
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as exit_context:
+                throttled.writemsr('IA32_HWP_REQUEST', 0, cpu=-1)
+
+        self.assertEqual(exit_context.exception.code, 1)
+        self.assertIn('Wrong writemsr cpu param', stderr.getvalue())
+
+    def test_readmsr_fails_safe_when_cpu_disappears(self):
+        throttled = load_throttled()
+        stderr = io.StringIO()
+
+        with mock.patch.object(throttled, '_ensure_msr_module', return_value='/dev/cpu/2/msr'):
+            with mock.patch.object(throttled.os, 'open', side_effect=FileNotFoundError(errno.ENOENT, 'CPU offline')):
+                with redirect_stderr(stderr):
+                    with self.assertRaises(SystemExit) as exit_context:
+                        throttled.readmsr('IA32_HWP_REQUEST', cpu=2)
+
+        self.assertEqual(exit_context.exception.code, 1)
+        self.assertIn('CPU 2 went offline while reading MSR IA32_HWP_REQUEST (774); aborting.', stderr.getvalue())
+
+    def test_hwp_probe_writes_back_only_cpu0(self):
+        throttled = load_throttled()
+
+        def readmsr(msr, *args, cpu=None, **kwargs):
+            self.assertEqual((msr, cpu), ('IA32_HWP_REQUEST', 0))
+            return 0x1234
+
+        with mock.patch.object(throttled, 'get_undervolt', return_value={'CORE': 0}):
+            with mock.patch.object(throttled, 'readmsr', side_effect=readmsr):
+                with mock.patch.object(throttled, 'writemsr') as writemsr:
+                    throttled.test_msr_rw_capabilities()
+
+        writemsr.assert_called_once_with('IA32_HWP_REQUEST', 0x1234, cpu=0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pr394_fixes.py
+++ b/tests/test_pr394_fixes.py
@@ -70,12 +70,19 @@ class PR394FixTests(unittest.TestCase):
         throttled = load_throttled()
         throttled.cpu_count = lambda: 2
 
-        with mock.patch.object(throttled, '_ensure_msr_module', return_value=['/dev/cpu/0/msr', '/dev/cpu/2/msr']):
-            with mock.patch.object(throttled.os, 'open', side_effect=[10, 20]):
-                with mock.patch.object(throttled.os, 'read', side_effect=[struct.pack('Q', 11), struct.pack('Q', 22)]):
+        def ensure_msr_module(cpu=None):
+            if cpu is None:
+                return ['/dev/cpu/0/msr', '/dev/cpu/2/msr']
+            return f'/dev/cpu/{cpu:d}/msr'
+
+        with mock.patch.object(throttled, '_ensure_msr_module', side_effect=ensure_msr_module):
+            with mock.patch.object(throttled.os, 'open', return_value=20) as open_:
+                with mock.patch.object(throttled.os, 'read', return_value=struct.pack('Q', 22)):
                     with mock.patch.object(throttled.os, 'lseek'):
                         with mock.patch.object(throttled.os, 'close'):
                             self.assertEqual(throttled.readmsr('MSR_PLATFORM_INFO', cpu=2), 22)
+
+        open_.assert_called_once_with('/dev/cpu/2/msr', throttled.os.O_RDONLY)
 
     def test_thermal_status_uses_values_read_from_available_msr_devices(self):
         throttled = load_throttled()

--- a/throttled.py
+++ b/throttled.py
@@ -12,7 +12,7 @@ import sys
 import traceback
 from collections import defaultdict
 from datetime import datetime
-from errno import EACCES, EIO, EPERM
+from errno import EACCES, EIO, ENOENT, EPERM
 from platform import uname
 from subprocess import check_output, CalledProcessError, PIPE
 from threading import Event, Thread, current_thread, main_thread
@@ -254,8 +254,19 @@ def get_msr_list():
     return [f'/dev/cpu/{cpu:d}/msr' for cpu in get_cpu_list()]
 
 
-def _ensure_msr_module():
-    """Return MSR devices, loading the msr module if the devices are missing."""
+def _ensure_msr_module(cpu=None):
+    """Return all MSR devices, or the MSR device for CPU N, loading the module if needed."""
+    if cpu is not None:
+        target = f'/dev/cpu/{cpu:d}/msr'
+        if not os.path.exists(target) and not os.path.exists('/sys/module/msr'):
+            try:
+                subprocess.check_call(('modprobe', 'msr'))
+            except subprocess.CalledProcessError:
+                fatal('Unable to load the msr module.')
+        if not os.path.exists(target):
+            fatal(f'CPU {cpu:d} has no MSR device under /dev/cpu; it may have gone offline.')
+        return target
+
     msr_list = get_msr_list()
     if not msr_list or not os.path.exists(msr_list[0]):
         try:
@@ -268,10 +279,12 @@ def _ensure_msr_module():
     return msr_list
 
 
-def writemsr(msr, val):
-    """Write a 64-bit value to the named MSR on every online CPU."""
-    msr_list = _ensure_msr_module()
+def writemsr(msr, val, cpu=None):
+    """Write a 64-bit value to the named MSR on every online CPU or CPU N."""
+    if cpu is not None and cpu < 0:
+        fatal('Wrong writemsr cpu param')
     try:
+        msr_list = [_ensure_msr_module(cpu)] if cpu is not None else _ensure_msr_module()
         for addr in msr_list:
             f = os.open(addr, os.O_WRONLY)
             try:
@@ -282,6 +295,8 @@ def writemsr(msr, val):
     except (IOError, OSError) as e:
         if TESTMSR:
             raise e
+        if cpu is not None and e.errno == ENOENT:
+            fatal(f'CPU {cpu:d} went offline while writing MSR {msr} ({MSR_DICT[msr]:x}); aborting.')
         if e.errno == EPERM or e.errno == EACCES:
             fatal(
                 f'Unable to write to MSR {msr} ({MSR_DICT[msr]:x}). Check that the msr kernel module '
@@ -304,8 +319,8 @@ def readmsr(msr, from_bit=0, to_bit=63, cpu=None, flatten=False):
         fatal('Wrong readmsr cpu param')
     if from_bit > to_bit:
         fatal('Wrong readmsr bit params')
-    msr_list = _ensure_msr_module()
     try:
+        msr_list = [_ensure_msr_module(cpu)] if cpu is not None else _ensure_msr_module()
         output = []
         for addr in msr_list:
             f = os.open(addr, os.O_RDONLY)
@@ -320,14 +335,13 @@ def readmsr(msr, from_bit=0, to_bit=63, cpu=None, flatten=False):
                 warning(f'Found multiple values for {msr:s} ({MSR_DICT[msr]:x}). This should never happen.')
             return output[0]
         if cpu is not None:
-            target = f'/dev/cpu/{cpu:d}/msr'
-            if target not in msr_list:
-                fatal(f'CPU {cpu:d} has no MSR device under /dev/cpu.')
-            return output[msr_list.index(target)]
+            return output[0]
         return output
     except (IOError, OSError) as e:
         if TESTMSR:
             raise e
+        if cpu is not None and e.errno == ENOENT:
+            fatal(f'CPU {cpu:d} went offline while reading MSR {msr} ({MSR_DICT[msr]:x}); aborting.')
         if e.errno == EPERM or e.errno == EACCES:
             fatal(
                 f'Unable to read from MSR {msr} ({MSR_DICT[msr]:x}). Check that the msr kernel module '
@@ -830,16 +844,19 @@ def set_hwp(performance_mode):
     """Set the IA32_HWP_REQUEST energy/performance preference field."""
     if performance_mode not in (True, False) or 'HWP' in UNSUPPORTED_FEATURES:
         return
-    # set HWP energy performance preference
-    cur_val = readmsr('IA32_HWP_REQUEST', cpu=0)
     hwp_mode = HWP_PERFORMANCE_VALUE if performance_mode is True else HWP_DEFAULT_VALUE
-    new_val = (cur_val & 0xFFFFFFFF00FFFFFF) | (hwp_mode << 24)
-
-    writemsr('IA32_HWP_REQUEST', new_val)
-    if args.debug:
-        read_value = readmsr('IA32_HWP_REQUEST', from_bit=24, to_bit=31)[0]
-        match = OK if hwp_mode == read_value else ERR
-        log(f'[D] HWP - write "{hwp_mode:#02x}" - read "{read_value:#02x}" - match {match}')
+    # Take one online-CPU snapshot, then use direct per-CPU RMW operations.
+    # A CPU that disappears after the snapshot is fatal rather than allowing a
+    # broadcast write or applying a value read from another logical CPU.
+    for addr in _ensure_msr_module():
+        cpu = int(os.path.basename(os.path.dirname(addr)))
+        cur_val = readmsr('IA32_HWP_REQUEST', cpu=cpu)
+        new_val = (cur_val & 0xFFFFFFFF00FFFFFF) | (hwp_mode << 24)
+        writemsr('IA32_HWP_REQUEST', new_val, cpu=cpu)
+        if args.debug:
+            read_value = readmsr('IA32_HWP_REQUEST', from_bit=24, to_bit=31, cpu=cpu)
+            match = OK if hwp_mode == read_value else ERR
+            log(f'[D] HWP CPU {cpu:d} - write "{hwp_mode:#02x}" - read "{read_value:#02x}" - match {match}')
 
 
 def set_disable_bdprochot():
@@ -1113,8 +1130,11 @@ def test_msr_rw_capabilities():
 
         try:
             log('[I] Testing if HWP is supported...')
+            # This is a startup feature probe, so CPU 0 is intentionally used
+            # as the representative CPU. set_hwp() later preserves each
+            # logical CPU's independent request with per-CPU RMW writes.
             cur_val = readmsr('IA32_HWP_REQUEST', cpu=0)
-            writemsr('IA32_HWP_REQUEST', cur_val)
+            writemsr('IA32_HWP_REQUEST', cur_val, cpu=0)
         except (IOError, OSError):
             warning('HWP seems not to be supported by your system, disabling.')
             UNSUPPORTED_FEATURES.append('HWP')

--- a/throttled.py
+++ b/throttled.py
@@ -845,9 +845,7 @@ def set_hwp(performance_mode):
     if performance_mode not in (True, False) or 'HWP' in UNSUPPORTED_FEATURES:
         return
     hwp_mode = HWP_PERFORMANCE_VALUE if performance_mode is True else HWP_DEFAULT_VALUE
-    # Take one online-CPU snapshot, then use direct per-CPU RMW operations.
-    # A CPU that disappears after the snapshot is fatal rather than allowing a
-    # broadcast write or applying a value read from another logical CPU.
+    # a CPU that disappears mid-loop is fatal rather than falling back to a broadcast write
     for addr in _ensure_msr_module():
         cpu = int(os.path.basename(os.path.dirname(addr)))
         cur_val = readmsr('IA32_HWP_REQUEST', cpu=cpu)
@@ -1130,9 +1128,6 @@ def test_msr_rw_capabilities():
 
         try:
             log('[I] Testing if HWP is supported...')
-            # This is a startup feature probe, so CPU 0 is intentionally used
-            # as the representative CPU. set_hwp() later preserves each
-            # logical CPU's independent request with per-CPU RMW writes.
             cur_val = readmsr('IA32_HWP_REQUEST', cpu=0)
             writemsr('IA32_HWP_REQUEST', cur_val, cpu=0)
         except (IOError, OSError):


### PR DESCRIPTION
## Summary

- read, modify, and write `IA32_HWP_REQUEST` independently for each logical CPU
- add targeted MSR access while preserving the existing broadcast default
- make the startup HWP capability probe write back only to CPU0
- fail explicitly if a target CPU disappears during a targeted access

## Root cause

`set_hwp()` read the request from CPU0, changed its EPP field, and passed the complete 64-bit value to the broadcast `writemsr()` path. `IA32_HWP_REQUEST` is logical-processor scoped, so this copied every other request field from CPU0 to all online CPUs.

The startup capability probe used the same broadcast path and could overwrite the other CPUs before normal operation began.

## Impact

Each logical CPU now keeps its independent request fields. Only bits 24:31 (the EPP field managed by throttled) are changed, using a direct per-CPU read-modify-write. Existing callers that omit `cpu=` retain the original broadcast behavior.

## Tests

- mocked heterogeneous per-CPU request values and bit preservation
- targeted read/write access and unchanged default broadcast behavior
- CPU hotplug/disappearing-device failure without fallback to broadcast
- CPU0-only startup probe
- targeted tests: 15/15
- full unittest suite: 57/57
- package tests: 15/15; built package source matches the candidate
- `git diff --check`

Black reports only formatting already present on the upstream base; the new and modified tests are formatted and the patch adds no formatting-only hunks.

Prepared with assistance from OpenAI Codex.
