### PR TITLE
Make Enabled a hardware-access barrier

### DIFF
--- a/tests/test_dbus_helpers.py
+++ b/tests/test_dbus_helpers.py
@@ -31,19 +31,24 @@ class DBusHelperTests(unittest.TestCase):
 
     def test_resume_callback_reapplies_settings_only_after_wake(self):
         throttled = load_throttled()
+        config = throttled.configparser.ConfigParser()
+        config.add_section('GENERAL')
+        config.set('GENERAL', 'Enabled', 'True')
         calls = []
 
         with mock.patch.object(throttled, 'undervolt', lambda config: calls.append(('undervolt', config))):
             with mock.patch.object(throttled, 'set_icc_max', lambda config: calls.append(('iccmax', config))):
-                throttled.handle_sleep_prepare(True, 'config')
+                throttled.handle_sleep_prepare(True, config)
                 self.assertEqual(calls, [])
 
-                throttled.handle_sleep_prepare(False, 'config')
-                self.assertEqual(calls, [('undervolt', 'config'), ('iccmax', 'config')])
+                throttled.handle_sleep_prepare(False, config)
+                self.assertEqual(calls, [('undervolt', config), ('iccmax', config)])
 
     def test_dbus_resume_signal_enabled_when_undervolt_or_iccmax_configured(self):
         throttled = load_throttled()
         config = throttled.configparser.ConfigParser()
+        config.add_section('GENERAL')
+        config.set('GENERAL', 'Enabled', 'True')
         config.add_section('UNDERVOLT')
         config.set('UNDERVOLT', 'CORE', '-50')
 

--- a/tests/test_enabled_barrier.py
+++ b/tests/test_enabled_barrier.py
@@ -3,6 +3,7 @@ import importlib.util
 import unittest
 from collections import defaultdict
 from pathlib import Path
+from threading import Thread
 from types import SimpleNamespace
 from unittest import mock
 
@@ -117,6 +118,51 @@ class EnabledBarrierTests(unittest.TestCase):
         writemsr.assert_not_called()
         undervolt.assert_not_called()
         thermal_status.assert_not_called()
+
+    def test_resume_callback_serializes_with_config_publication(self):
+        throttled = load_throttled()
+        state = {'config': make_config(enabled=True), 'regs': defaultdict(dict)}
+
+        with mock.patch.object(throttled, 'undervolt') as undervolt:
+            with mock.patch.object(throttled, 'set_icc_max') as set_icc_max:
+                with throttled.config_lock:
+                    resume = Thread(target=throttled.handle_sleep_prepare, args=(False, state))
+                    resume.start()
+                    # the callback must block on the lock instead of capturing the old config
+                    resume.join(timeout=0.2)
+                    self.assertTrue(resume.is_alive())
+                    undervolt.assert_not_called()
+                    state['config'] = make_config(enabled=False)
+                resume.join(timeout=5)
+
+        self.assertFalse(resume.is_alive())
+        undervolt.assert_not_called()
+        set_icc_max.assert_not_called()
+
+    def test_config_publication_happens_under_the_shared_lock(self):
+        throttled = load_throttled()
+        old_config = make_config(enabled=True, autoreload=True)
+        new_config = make_config(enabled=False, autoreload=True)
+        published = []
+
+        class PublishRecorder(dict):
+            def __setitem__(self, key, value):
+                published.append(throttled.config_lock.locked())
+                super().__setitem__(key, value)
+
+        state = PublishRecorder({'config': old_config, 'regs': defaultdict(dict)})
+
+        with mock.patch.object(throttled, 'read_mchbar_base', return_value=0):
+            with mock.patch.object(throttled, 'MMIO', side_effect=throttled.MMIOError):
+                with mock.patch.object(throttled, 'warning'):
+                    with mock.patch.object(throttled, 'get_config_write_time', side_effect=(1, 2)):
+                        with mock.patch.object(
+                            throttled, 'reload_config', return_value=(new_config, defaultdict(dict))
+                        ):
+                            throttled._power_thread(state, StopAfterWait(), (6, 158, 13))
+
+        self.assertEqual(published, [True, True])
+        self.assertIs(state['config'], new_config)
 
 
 if __name__ == '__main__':

--- a/tests/test_enabled_barrier.py
+++ b/tests/test_enabled_barrier.py
@@ -1,0 +1,123 @@
+import configparser
+import importlib.util
+import unittest
+from collections import defaultdict
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_throttled():
+    spec = importlib.util.spec_from_file_location('throttled_under_test', ROOT / 'throttled.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.args = SimpleNamespace(log=None, debug=False, config='/tmp/throttled.conf', monitor=None)
+    module.log_history.clear()
+    module.power['source'] = 'AC'
+    module.power['method'] = 'dbus'
+    return module
+
+
+def make_config(enabled=True, autoreload=False):
+    config = configparser.ConfigParser()
+    config.add_section('GENERAL')
+    config.set('GENERAL', 'Enabled', str(enabled))
+    config.set('GENERAL', 'Autoreload', str(autoreload))
+    config.add_section('AC')
+    config.set('AC', 'Update_Rate_s', '0.001')
+    return config
+
+
+class StopAfterWait:
+    def __init__(self):
+        self.stopped = False
+
+    def is_set(self):
+        return self.stopped
+
+    def wait(self, timeout):
+        self.stopped = True
+
+
+class EnabledBarrierTests(unittest.TestCase):
+    def test_initially_disabled_config_exits_before_hardware_checks(self):
+        throttled = load_throttled()
+        config = make_config(enabled=False)
+        parsed_args = SimpleNamespace(log=None, debug=False, config='/tmp/throttled.conf', monitor=None, force=False)
+        parser = mock.Mock()
+        parser.parse_args.return_value = parsed_args
+
+        with mock.patch.object(throttled, 'build_arg_parser', return_value=parser):
+            with mock.patch.object(throttled, 'load_config', return_value=config):
+                with mock.patch.object(throttled, 'check_kernel') as check_kernel:
+                    with mock.patch.object(throttled, 'check_cpu') as check_cpu:
+                        with mock.patch.object(throttled, 'set_msr_allow_writes') as allow_writes:
+                            with mock.patch.object(throttled, 'test_msr_rw_capabilities') as test_msr:
+                                throttled.main()
+
+        check_kernel.assert_not_called()
+        check_cpu.assert_not_called()
+        allow_writes.assert_not_called()
+        test_msr.assert_not_called()
+
+    def test_disabled_config_blocks_resume_writes(self):
+        throttled = load_throttled()
+        config = make_config(enabled=False)
+
+        with mock.patch.object(throttled, 'undervolt') as undervolt:
+            with mock.patch.object(throttled, 'set_icc_max') as set_icc_max:
+                throttled.handle_sleep_prepare(False, config)
+
+        undervolt.assert_not_called()
+        set_icc_max.assert_not_called()
+        self.assertFalse(throttled.should_listen_for_resume(config))
+
+    def test_disabled_reload_does_not_calculate_or_apply_hardware_settings(self):
+        throttled = load_throttled()
+        config = make_config(enabled=False, autoreload=True)
+
+        with mock.patch.object(throttled, 'load_config', return_value=config):
+            with mock.patch.object(throttled, 'calc_reg_values') as calc_reg_values:
+                with mock.patch.object(throttled, 'undervolt') as undervolt:
+                    with mock.patch.object(throttled, 'set_icc_max') as set_icc_max:
+                        with mock.patch.object(throttled, 'set_hwp') as set_hwp:
+                            reloaded_config, regs = throttled.reload_config()
+
+        self.assertIs(reloaded_config, config)
+        self.assertEqual(dict(regs), {})
+        calc_reg_values.assert_not_called()
+        undervolt.assert_not_called()
+        set_icc_max.assert_not_called()
+        set_hwp.assert_not_called()
+
+    def test_enabled_to_disabled_reload_is_an_immediate_write_barrier(self):
+        throttled = load_throttled()
+        throttled.args.debug = True
+        old_config = make_config(enabled=True, autoreload=True)
+        new_config = make_config(enabled=False, autoreload=True)
+        state = {'config': old_config, 'regs': {'AC': {'MSR_PKG_POWER_LIMIT': 0x1234}}}
+
+        with mock.patch.object(throttled, 'read_mchbar_base', return_value=0):
+            with mock.patch.object(throttled, 'MMIO', side_effect=throttled.MMIOError):
+                with mock.patch.object(throttled, 'warning'):
+                    with mock.patch.object(throttled, 'get_config_write_time', side_effect=(1, 2)):
+                        with mock.patch.object(
+                            throttled, 'reload_config', return_value=(new_config, defaultdict(dict))
+                        ):
+                            with mock.patch.object(throttled, 'writemsr') as writemsr:
+                                with mock.patch.object(throttled, 'undervolt') as undervolt:
+                                    with mock.patch.object(
+                                        throttled, 'get_reset_thermal_status'
+                                    ) as thermal_status:
+                                        throttled._power_thread(state, StopAfterWait(), (6, 158, 13))
+
+        writemsr.assert_not_called()
+        undervolt.assert_not_called()
+        thermal_status.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_power_source_flip.py
+++ b/tests/test_power_source_flip.py
@@ -44,9 +44,16 @@ class PowerSourceFlipTests(unittest.TestCase):
     def test_resume_listener_checks_the_planes_each_key_actually_supports(self):
         throttled = load_throttled()
 
-        self.assertFalse(throttled.should_listen_for_resume(make_config({'ICCMAX.AC': {'UNCORE': 200}})))
-        self.assertTrue(throttled.should_listen_for_resume(make_config({'ICCMAX.AC': {'CORE': 200}})))
-        self.assertTrue(throttled.should_listen_for_resume(make_config({'UNDERVOLT.AC': {'ANALOGIO': -50}})))
+        enabled = {'Enabled': True}
+        self.assertFalse(
+            throttled.should_listen_for_resume(make_config({'GENERAL': enabled, 'ICCMAX.AC': {'UNCORE': 200}}))
+        )
+        self.assertTrue(
+            throttled.should_listen_for_resume(make_config({'GENERAL': enabled, 'ICCMAX.AC': {'CORE': 200}}))
+        )
+        self.assertTrue(
+            throttled.should_listen_for_resume(make_config({'GENERAL': enabled, 'UNDERVOLT.AC': {'ANALOGIO': -50}}))
+        )
 
     def test_set_icc_max_honors_an_explicit_power_source(self):
         throttled = load_throttled()
@@ -77,7 +84,7 @@ class PowerSourceFlipTests(unittest.TestCase):
         throttled.power['method'] = 'polling'
         config = make_config(
             {
-                'GENERAL': {'Autoreload': 'False'},
+                'GENERAL': {'Enabled': 'True', 'Autoreload': 'False'},
                 'AC': {'Update_Rate_s': '5'},
                 'BATTERY': {'Update_Rate_s': '30'},
             }

--- a/tests/test_pr394_fixes.py
+++ b/tests/test_pr394_fixes.py
@@ -24,6 +24,7 @@ def load_throttled():
 def make_config(autoreload=False, update_rate='0.001', trip_temp=None):
     config = __import__('configparser').ConfigParser()
     config.add_section('GENERAL')
+    config.set('GENERAL', 'Enabled', 'True')
     config.set('GENERAL', 'Autoreload', 'True' if autoreload else 'False')
     for section in ('AC', 'BATTERY'):
         config.add_section(section)
@@ -140,14 +141,15 @@ class PR394FixTests(unittest.TestCase):
 
     def test_sleep_callback_reads_current_config_from_state(self):
         throttled = load_throttled()
-        state = {'config': 'updated-config'}
+        updated_config = make_config()
+        state = {'config': updated_config}
         calls = []
 
         with mock.patch.object(throttled, 'undervolt', lambda config: calls.append(('undervolt', config))):
             with mock.patch.object(throttled, 'set_icc_max', lambda config: calls.append(('iccmax', config))):
                 throttled.handle_sleep_prepare(False, state)
 
-        self.assertEqual(calls, [('undervolt', 'updated-config'), ('iccmax', 'updated-config')])
+        self.assertEqual(calls, [('undervolt', updated_config), ('iccmax', updated_config)])
 
 
 if __name__ == '__main__':

--- a/throttled.py
+++ b/throttled.py
@@ -414,11 +414,17 @@ def _current_config(config_or_state):
     return config_or_state['config'] if isinstance(config_or_state, dict) else config_or_state
 
 
+def config_is_enabled(config):
+    """Return whether hardware changes are enabled in the loaded config."""
+    return config.getboolean('GENERAL', 'Enabled', fallback=False)
+
+
 def handle_sleep_prepare(sleeping, config_or_state):
     if not sleeping:
         config = _current_config(config_or_state)
-        undervolt(config)
-        set_icc_max(config)
+        if config_is_enabled(config):
+            undervolt(config)
+            set_icc_max(config)
 
 
 def handle_ac_properties_changed(if_name, changed, invalidated):
@@ -428,7 +434,7 @@ def handle_ac_properties_changed(if_name, changed, invalidated):
 
 
 def should_listen_for_resume(config):
-    return any(
+    return config_is_enabled(config) and any(
         config.getfloat(key, plane, fallback=0) != 0
         for keys, planes in ((UNDERVOLT_KEYS, VOLTAGE_PLANES), (ICCMAX_KEYS, CURRENT_PLANES))
         for key in keys
@@ -865,6 +871,9 @@ def get_config_write_time():
 def reload_config():
     """Re-read the config and re-apply undervolt, IccMax and HWP settings."""
     config = load_config()
+    if not config_is_enabled(config):
+        log('[I] Reloading changes.')
+        return config, defaultdict(dict)
     regs = calc_reg_values(get_cpu_platform_info(), config)
     undervolt(config)
     set_icc_max(config)
@@ -939,13 +948,6 @@ def _power_thread(state, exit_event, cpuid):
         get_config_write_time() if config.getboolean('GENERAL', 'Autoreload', fallback=False) else None
     )
     while not exit_event.is_set():
-        # log thermal status
-        if args.debug:
-            thermal_status = get_reset_thermal_status()
-            for index, core_thermal_status in enumerate(thermal_status):
-                for key, value in core_thermal_status.items():
-                    log(f'[D] core {index} thermal status: {key.replace("_", " ")} = {value}')
-
         # Reload config on changes (unless it's deleted)
         if config.getboolean('GENERAL', 'Autoreload', fallback=False):
             config_write_time = get_config_write_time()
@@ -961,6 +963,20 @@ def _power_thread(state, exit_event, cpuid):
         # snapshot the power source once per iteration: the D-Bus callback can
         # flip it concurrently and every write below must agree on one profile
         power_source = power['source']
+
+        # Enabled=False is a hard write barrier, including the iteration that
+        # observes an enabled -> disabled autoreload transition.
+        if not config_is_enabled(config):
+            applied_source = power_source
+            exit_event.wait(get_update_rate(config, power_source))
+            continue
+
+        # log thermal status
+        if args.debug:
+            thermal_status = get_reset_thermal_status()
+            for index, core_thermal_status in enumerate(thermal_status):
+                for key, value in core_thermal_status.items():
+                    log(f'[D] core {index} thermal status: {key.replace("_", " ")} = {value}')
 
         # re-apply the one-shot per-profile settings when the power source flips
         if power_source != applied_source:
@@ -1212,6 +1228,12 @@ def main():
             args.log = None
             fatal(f'Unable to write to the log file: {e}')
 
+    log('[I] Loading config file.')
+    config = load_config()
+    if not config_is_enabled(config):
+        log('[I] Throttled is disabled in config file... Quitting. :(')
+        return
+
     cpuid = None
     if not args.force:
         check_kernel()
@@ -1221,8 +1243,6 @@ def main():
 
     test_msr_rw_capabilities()
 
-    log('[I] Loading config file.')
-    config = load_config()
     power['source'] = 'BATTERY' if is_on_battery(config) else 'AC'
 
     platform_info = get_cpu_platform_info()
@@ -1230,10 +1250,6 @@ def main():
         for key, value in platform_info.items():
             log(f'[D] cpu platform info: {key.replace("_", " ")} = {value}')
     regs = calc_reg_values(platform_info, config)
-
-    if not config.getboolean('GENERAL', 'Enabled', fallback=False):
-        log('[I] Throttled is disabled in config file... Quitting. :(')
-        return
 
     undervolt(config)
     set_icc_max(config)

--- a/throttled.py
+++ b/throttled.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from errno import EACCES, EIO, EPERM
 from platform import uname
 from subprocess import check_output, CalledProcessError, PIPE
-from threading import Event, Thread, current_thread, main_thread
+from threading import Event, Lock, Thread, current_thread, main_thread
 from time import time
 
 from mmio import MMIO, MMIOError
@@ -35,6 +35,8 @@ POWER_PROFILES = ('AC', 'BATTERY')
 UNDERVOLT_KEYS = ('UNDERVOLT', 'UNDERVOLT.AC', 'UNDERVOLT.BATTERY')
 ICCMAX_KEYS = ('ICCMAX', 'ICCMAX.AC', 'ICCMAX.BATTERY')
 power = {'source': None, 'method': 'polling'}
+# serializes config publication with the resume callback's read-then-write
+config_lock = Lock()
 MSR_DICT = {
     'MSR_PLATFORM_INFO': 0xCE,
     'MSR_OC_MAILBOX': 0x150,
@@ -421,10 +423,11 @@ def config_is_enabled(config):
 
 def handle_sleep_prepare(sleeping, config_or_state):
     if not sleeping:
-        config = _current_config(config_or_state)
-        if config_is_enabled(config):
-            undervolt(config)
-            set_icc_max(config)
+        with config_lock:
+            config = _current_config(config_or_state)
+            if config_is_enabled(config):
+                undervolt(config)
+                set_icc_max(config)
 
 
 def handle_ac_properties_changed(if_name, changed, invalidated):
@@ -953,7 +956,8 @@ def _power_thread(state, exit_event, cpuid):
             config_write_time = get_config_write_time()
             if config_write_time and last_config_write_time != config_write_time:
                 last_config_write_time = config_write_time
-                state['config'], state['regs'] = reload_config()
+                with config_lock:
+                    state['config'], state['regs'] = reload_config()
                 config, regs = state['config'], state['regs']
 
         # switch back to sysfs polling


### PR DESCRIPTION
## Summary

`Enabled: False` was not a hardware barrier:

- at startup, `set_msr_allow_writes()` and the MSR write probe ran before the config was even read — a disabled daemon still flipped the `msr.allow_writes` module parameter and wrote `IA32_HWP_REQUEST` before quitting;
- with `Autoreload: True`, editing the config to `Enabled: False` was a no-op: the reload re-applied undervolt/IccMax/HWP and the main loop kept writing the thermal/power MSRs;
- the login1 resume callback re-applied undervolt/IccMax on wake regardless of the flag.

The config is now loaded (and `Enabled` checked) first, the reload/resume paths are gated, and the main loop becomes a write barrier from the iteration that observes a disabled reload. The documented exit-on-startup-disabled contract is unchanged, so systemd/OpenRC/runit semantics stay as they are.

This replaces the earlier version of this PR: the resident-daemon/auto-resume redesign is gone — same barrier, no product-semantics change.

Prepared with assistance from OpenAI Codex.
