### PR TITLE
Reject unencodable package power limits

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -3,6 +3,7 @@ import io
 import os
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -151,6 +152,33 @@ class ConfigValidationTests(unittest.TestCase):
         output = next(call.args[0] for call in log.call_args_list if 'Package:' in call.args[0])
         self.assertIn('Package: 15.0 W', output)
         self.assertIn('Total: 35.0 W', output)
+
+    def test_load_config_disables_malformed_power_limits(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[GENERAL]\nEnabled: True\n'
+            '[AC]\nUpdate_Rate_s: 5\nPL1_Tdp_W: inf\nPL2_Duration_s: nan\nPL2_Tdp_W: abc\nPL1_Duration_s: 1\n'
+        )
+
+        with mock.patch.object(throttled, 'warning'):
+            config = throttled.load_config()
+
+        self.assertFalse(config.has_option('AC', 'PL1_Tdp_W'))
+        self.assertFalse(config.has_option('AC', 'PL2_Duration_s'))
+        self.assertFalse(config.has_option('AC', 'PL2_Tdp_W'))
+        self.assertEqual(config.getfloat('AC', 'PL1_Duration_s'), 1)
+        self.assertEqual(config.getfloat('AC', 'Update_Rate_s'), 5)
+
+    def test_load_config_still_dies_on_a_nonfinite_update_rate(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config('[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: nan\n')
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr):
+            with self.assertRaises(SystemExit):
+                throttled.load_config()
+
+        self.assertIn('must be a finite number', stderr.getvalue())
 
 
 if __name__ == '__main__':

--- a/tests/test_msr_encoding.py
+++ b/tests/test_msr_encoding.py
@@ -1,6 +1,8 @@
 import configparser
 import importlib.util
+import io
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -74,6 +76,53 @@ class MsrEncodingTests(unittest.TestCase):
         self.assertEqual(throttled.calc_icc_max_msr('CORE', 0x3FF / 4) & 0x3FF, 0x3FF)
         with self.assertRaises(AssertionError):
             throttled.calc_icc_max_msr('CORE', 256)
+
+    def test_package_power_limit_encoder_rejects_field_spill(self):
+        throttled = load_throttled()
+
+        value = throttled._encode_pkg_power_limit(0x7FFF, 0x7F, 0x7FFF, 0x7F)
+        self.assertEqual(
+            value,
+            0x7FFF | (1 << 15) | (1 << 16) | (0x7F << 17) | (0x7FFF << 32) | (1 << 47) | (0x7F << 49),
+        )
+        with self.assertRaisesRegex(ValueError, 'PL1'):
+            throttled._encode_pkg_power_limit(0x8000, 0, 1, 0)
+        with self.assertRaisesRegex(ValueError, 'PL2'):
+            throttled._encode_pkg_power_limit(1, 0, 0x8000, 0)
+
+    def test_calculated_package_power_limit_rejects_unencodable_wattage(self):
+        throttled = load_throttled()
+        config = make_config(
+            {
+                'GENERAL': {'Enabled': 'True'},
+                'AC': {
+                    'Update_Rate_s': '5',
+                    'PL1_Tdp_W': str(0x8000),
+                    'PL1_Duration_s': '1',
+                    'PL2_Tdp_W': '20',
+                    'PL2_Duration_s': '1',
+                },
+            }
+        )
+        platform_info = {
+            'feature_programmable_temperature_target': 0,
+            'feature_programmable_tdp_limit': 0,
+        }
+
+        stderr = io.StringIO()
+        with mock.patch.object(throttled, 'get_power_unit', return_value=1):
+            with mock.patch.object(
+                throttled,
+                'get_cur_pkg_power_limits',
+                return_value={'PL1': 0, 'TW1': 0, 'PL2': 0, 'TW2': 0},
+            ):
+                with mock.patch.object(throttled, 'calc_time_window_vars', return_value=(0, 0)):
+                    with mock.patch.object(throttled, 'warning'):
+                        with redirect_stderr(stderr):
+                            with self.assertRaises(SystemExit):
+                                throttled.calc_reg_values(platform_info, config)
+
+        self.assertIn('PL1', stderr.getvalue())
 
 
 if __name__ == '__main__':

--- a/throttled.py
+++ b/throttled.py
@@ -32,6 +32,8 @@ DBUS_PROPERTIES_INTERFACE = 'org.freedesktop.DBus.Properties'
 VOLTAGE_PLANES = {'CORE': 0, 'GPU': 1, 'CACHE': 2, 'UNCORE': 3, 'ANALOGIO': 4}
 CURRENT_PLANES = {'CORE': 0, 'GPU': 1, 'CACHE': 2}
 TRIP_TEMP_RANGE = [40, 97]
+PKG_POWER_LIMIT_POWER_MASK = (1 << 15) - 1
+PKG_POWER_LIMIT_TIME_WINDOW_MASK = (1 << 7) - 1
 POWER_PROFILES = ('AC', 'BATTERY')
 UNDERVOLT_KEYS = ('UNDERVOLT', 'UNDERVOLT.AC', 'UNDERVOLT.BATTERY')
 ICCMAX_KEYS = ('ICCMAX', 'ICCMAX.AC', 'ICCMAX.BATTERY')
@@ -567,6 +569,30 @@ def calc_time_window_vars(t):
     raise ValueError('Unable to find a good combination!')
 
 
+def _encode_pkg_power_limit(pl1, tw1, pl2, tw2):
+    """Encode MSR_PKG_POWER_LIMIT fields without allowing adjacent-bit spill."""
+    fields = (
+        ('PL1', pl1, PKG_POWER_LIMIT_POWER_MASK),
+        ('TW1', tw1, PKG_POWER_LIMIT_TIME_WINDOW_MASK),
+        ('PL2', pl2, PKG_POWER_LIMIT_POWER_MASK),
+        ('TW2', tw2, PKG_POWER_LIMIT_TIME_WINDOW_MASK),
+    )
+    encoded = {}
+    for name, value, mask in fields:
+        if not isinstance(value, int) or not 0 <= value <= mask:
+            raise ValueError(f'{name:s} value {value!r} does not fit its {mask.bit_length():d}-bit field.')
+        encoded[name] = value
+    return (
+        encoded['PL1']
+        | (1 << 15)
+        | (1 << 16)
+        | (encoded['TW1'] << 17)
+        | (encoded['PL2'] << 32)
+        | (1 << 47)
+        | (encoded['TW2'] << 49)
+    )
+
+
 def _undervolt_offset_to_ticks(offset):
     """Convert an undervolt in mV to the signed 11-bit mailbox field."""
     try:
@@ -722,7 +748,16 @@ def load_config():
     # config values sanity check
     for power_source in power_profiles:
         for option in ('Update_Rate_s', 'PL1_Tdp_W', 'PL1_Duration_s', 'PL2_Tdp_W', 'PL2_Duration_S'):
-            value = config.getfloat(power_source, option, fallback=None)
+            try:
+                value = config.getfloat(power_source, option, fallback=None)
+                if value is not None and not math.isfinite(value):
+                    raise ValueError(value)
+            except ValueError:
+                if option == 'Update_Rate_s':
+                    fatal(f'The mandatory "Update_Rate_s" parameter in [{power_source:s}] must be a finite number.')
+                warning(f'Invalid "{option:s}" value in [{power_source:s}]; leaving it disabled.', oneshot=False)
+                config.remove_option(power_source, option)
+                value = None
             if value is not None:
                 config.set(power_source, option, str(max(0.001, value)))
             elif option == 'Update_Rate_s':
@@ -864,9 +899,10 @@ def calc_reg_values(platform_info, config):
                 Y, Z = calc_time_window_vars(PL2_Duration_s)
                 TW2 = Y | (Z << 5)
 
-            regs[power_source]['MSR_PKG_POWER_LIMIT'] = (
-                PL1 | (1 << 15) | (1 << 16) | (TW1 << 17) | (PL2 << 32) | (1 << 47) | (TW2 << 49)
-            )
+            try:
+                regs[power_source]['MSR_PKG_POWER_LIMIT'] = _encode_pkg_power_limit(PL1, TW1, PL2, TW2)
+            except ValueError as e:
+                fatal(f'Invalid package power limits in [{power_source:s}]: {e}')
         else:
             log(f'[I] {power_source:s} package power limits are disabled in config.')
 


### PR DESCRIPTION
## Summary

`MSR_PKG_POWER_LIMIT` is composed with no bound on the PL1/PL2 fields (unsigned 15-bit). With a 0.125 W/tick RAPL unit, `PL1_Tdp_W: 4096` encodes to `0x8000`: measured on master, the resulting register is `0x0004816800dd8000` — the PL1 field reads **0 W with enable and clamp still asserted**. Larger typos also corrupt TW1 (`99999` → TW1 1→7).

The fix bounds all four fields in one place at the composition site (`_encode_pkg_power_limit`), and config loading now disables malformed power-limit options (non-numeric or non-finite) with a warning instead of normalizing them — a non-finite `Update_Rate_s` stays fatal since it is mandatory.

This replaces the earlier, larger version of this PR: the `main()` reordering is gone (it belonged to a different change and collided with #404) and invalid config no longer aborts the daemon, matching `load_config()`'s documented clamp-and-warn contract. Values that round to 0 ticks keep upstream's historical `max(0.001, value)` floor behavior — out of scope here.

Prepared with assistance from OpenAI Codex.
