### PR TITLE
Handle unsupported undervolting in monitor mode

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -179,6 +179,60 @@ class ConfigValidationTests(unittest.TestCase):
                 throttled.load_config()
 
         self.assertIn('must be a finite number', stderr.getvalue())
+    def test_monitor_reports_unsupported_undervolt_as_na(self):
+        throttled = load_throttled()
+        throttled.UNSUPPORTED_FEATURES.append('UNDERVOLT')
+
+        def readmsr(msr, *args, **kwargs):
+            if msr == 'MSR_RAPL_POWER_UNIT':
+                return 0
+            if msr in {
+                'MSR_INTEL_PKG_ENERGY_STATUS',
+                'MSR_PP1_ENERGY_STATUS',
+                'MSR_DRAM_ENERGY_STATUS',
+            }:
+                return 0
+            return 0
+
+        with mock.patch.object(throttled, 'readmsr', side_effect=readmsr):
+            with mock.patch.object(throttled, 'get_undervolt') as get_undervolt:
+                with mock.patch.object(
+                    throttled, 'get_icc_max', return_value=dict.fromkeys(throttled.CURRENT_PLANES, 0)
+                ):
+                    with mock.patch.object(throttled, 'log') as log:
+                        throttled.monitor(StopAfterWait(), 1)
+                        throttled.monitor(StopAfterWait(), 1)
+
+        get_undervolt.assert_not_called()
+        messages = [
+            call.args[0]
+            for call in log.call_args_list
+            if call.args[0].startswith('[D] Undervolt offsets:')
+        ]
+        self.assertEqual(messages, ['[D] Undervolt offsets: N/A (unsupported)'] * 2)
+
+    def test_monitor_keeps_supported_undervolt_output(self):
+        throttled = load_throttled()
+        undervolt = dict.fromkeys(throttled.VOLTAGE_PLANES, -50)
+
+        with mock.patch.object(throttled, 'readmsr', return_value=0):
+            with mock.patch.object(throttled, 'get_undervolt', return_value=undervolt):
+                with mock.patch.object(
+                    throttled, 'get_icc_max', return_value=dict.fromkeys(throttled.CURRENT_PLANES, 0)
+                ):
+                    with mock.patch.object(throttled, 'log') as log:
+                        throttled.monitor(StopAfterWait(), 1)
+
+        self.assertTrue(any('CORE: -50.00 mV' in call.args[0] for call in log.call_args_list))
+
+    def test_monitor_propagates_undervolt_read_errors(self):
+        throttled = load_throttled()
+        error = OSError('transient MSR read failure')
+
+        with mock.patch.object(throttled, 'readmsr', return_value=0):
+            with mock.patch.object(throttled, 'get_undervolt', side_effect=error):
+                with self.assertRaisesRegex(OSError, 'transient MSR read failure'):
+                    throttled.monitor(StopAfterWait(), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -180,9 +180,45 @@ class ConfigValidationTests(unittest.TestCase):
 
         self.assertIn('must be a finite number', stderr.getvalue())
 
-    def test_monitor_skips_the_oc_mailbox_when_undervolt_is_unsupported(self):
+    def test_monitor_skips_only_the_undervolt_read_when_undervolt_is_unsupported(self):
         throttled = load_throttled()
         throttled.UNSUPPORTED_FEATURES.append('UNDERVOLT')
+
+        with mock.patch.object(throttled, 'readmsr', return_value=0):
+            with mock.patch.object(throttled, 'get_undervolt') as get_undervolt:
+                with mock.patch.object(
+                    throttled, 'get_icc_max', return_value=dict.fromkeys(throttled.CURRENT_PLANES, 0)
+                ) as get_icc_max:
+                    with mock.patch.object(throttled, 'log') as log:
+                        throttled.monitor(StopAfterWait(), 1)
+
+        get_undervolt.assert_not_called()
+        get_icc_max.assert_called_once_with(convert=True)
+        messages = [call.args[0] for call in log.call_args_list]
+        self.assertIn('[D] Undervolt offsets: unsupported', messages)
+        self.assertIn('[D] IccMax: CORE: 0.00 A | GPU: 0.00 A | CACHE: 0.00 A', messages)
+
+    def test_monitor_skips_only_the_iccmax_read_when_iccmax_is_unsupported(self):
+        throttled = load_throttled()
+        throttled.UNSUPPORTED_FEATURES.append('ICCMAX')
+
+        with mock.patch.object(throttled, 'readmsr', return_value=0):
+            with mock.patch.object(
+                throttled, 'get_undervolt', return_value=dict.fromkeys(throttled.VOLTAGE_PLANES, -50)
+            ) as get_undervolt:
+                with mock.patch.object(throttled, 'get_icc_max') as get_icc_max:
+                    with mock.patch.object(throttled, 'log') as log:
+                        throttled.monitor(StopAfterWait(), 1)
+
+        get_undervolt.assert_called_once_with(convert=True)
+        get_icc_max.assert_not_called()
+        messages = [call.args[0] for call in log.call_args_list]
+        self.assertIn('[D] IccMax: unsupported', messages)
+        self.assertTrue(any('CORE: -50.00 mV' in message for message in messages))
+
+    def test_monitor_skips_the_oc_mailbox_when_both_probes_fail(self):
+        throttled = load_throttled()
+        throttled.UNSUPPORTED_FEATURES.extend(('UNDERVOLT', 'ICCMAX'))
 
         with mock.patch.object(throttled, 'readmsr', return_value=0):
             with mock.patch.object(throttled, 'get_undervolt') as get_undervolt:
@@ -209,6 +245,51 @@ class ConfigValidationTests(unittest.TestCase):
                         throttled.monitor(StopAfterWait(), 1)
 
         self.assertTrue(any('CORE: -50.00 mV' in call.args[0] for call in log.call_args_list))
+
+    def test_probe_marks_only_undervolt_when_its_mailbox_command_fails(self):
+        throttled = load_throttled()
+
+        with mock.patch.object(throttled, 'get_undervolt', side_effect=OSError):
+            with mock.patch.object(
+                throttled, 'get_icc_max', return_value=dict.fromkeys(throttled.CURRENT_PLANES, 0)
+            ):
+                with mock.patch.object(throttled, 'readmsr', return_value=0):
+                    with mock.patch.object(throttled, 'writemsr'):
+                        with mock.patch.object(throttled, 'warning'):
+                            with mock.patch.object(throttled, 'log'):
+                                throttled.test_msr_rw_capabilities()
+
+        self.assertIn('UNDERVOLT', throttled.UNSUPPORTED_FEATURES)
+        self.assertNotIn('ICCMAX', throttled.UNSUPPORTED_FEATURES)
+
+    def test_probe_marks_only_iccmax_when_its_mailbox_command_fails(self):
+        throttled = load_throttled()
+
+        with mock.patch.object(
+            throttled, 'get_undervolt', return_value=dict.fromkeys(throttled.VOLTAGE_PLANES, 0)
+        ):
+            with mock.patch.object(throttled, 'get_icc_max', side_effect=OSError):
+                with mock.patch.object(throttled, 'readmsr', return_value=0):
+                    with mock.patch.object(throttled, 'writemsr'):
+                        with mock.patch.object(throttled, 'warning'):
+                            with mock.patch.object(throttled, 'log'):
+                                throttled.test_msr_rw_capabilities()
+
+        self.assertNotIn('UNDERVOLT', throttled.UNSUPPORTED_FEATURES)
+        self.assertIn('ICCMAX', throttled.UNSUPPORTED_FEATURES)
+
+    def test_set_icc_max_skips_the_mailbox_when_iccmax_is_unsupported(self):
+        throttled = load_throttled()
+        throttled.UNSUPPORTED_FEATURES.append('ICCMAX')
+        config = throttled.configparser.ConfigParser()
+        config.add_section('ICCMAX.AC')
+        config.set('ICCMAX.AC', 'CORE', '100')
+
+        with mock.patch.object(throttled, 'writemsr') as writemsr:
+            throttled.set_icc_max(config, source='AC')
+
+        writemsr.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -179,37 +179,22 @@ class ConfigValidationTests(unittest.TestCase):
                 throttled.load_config()
 
         self.assertIn('must be a finite number', stderr.getvalue())
-    def test_monitor_reports_unsupported_undervolt_as_na(self):
+
+    def test_monitor_skips_the_oc_mailbox_when_undervolt_is_unsupported(self):
         throttled = load_throttled()
         throttled.UNSUPPORTED_FEATURES.append('UNDERVOLT')
 
-        def readmsr(msr, *args, **kwargs):
-            if msr == 'MSR_RAPL_POWER_UNIT':
-                return 0
-            if msr in {
-                'MSR_INTEL_PKG_ENERGY_STATUS',
-                'MSR_PP1_ENERGY_STATUS',
-                'MSR_DRAM_ENERGY_STATUS',
-            }:
-                return 0
-            return 0
-
-        with mock.patch.object(throttled, 'readmsr', side_effect=readmsr):
+        with mock.patch.object(throttled, 'readmsr', return_value=0):
             with mock.patch.object(throttled, 'get_undervolt') as get_undervolt:
-                with mock.patch.object(
-                    throttled, 'get_icc_max', return_value=dict.fromkeys(throttled.CURRENT_PLANES, 0)
-                ):
+                with mock.patch.object(throttled, 'get_icc_max') as get_icc_max:
                     with mock.patch.object(throttled, 'log') as log:
-                        throttled.monitor(StopAfterWait(), 1)
                         throttled.monitor(StopAfterWait(), 1)
 
         get_undervolt.assert_not_called()
-        messages = [
-            call.args[0]
-            for call in log.call_args_list
-            if call.args[0].startswith('[D] Undervolt offsets:')
-        ]
-        self.assertEqual(messages, ['[D] Undervolt offsets: N/A (unsupported)'] * 2)
+        get_icc_max.assert_not_called()
+        messages = [call.args[0] for call in log.call_args_list]
+        self.assertIn('[D] Undervolt offsets: unsupported', messages)
+        self.assertIn('[D] IccMax: unsupported', messages)
 
     def test_monitor_keeps_supported_undervolt_output(self):
         throttled = load_throttled()
@@ -224,16 +209,6 @@ class ConfigValidationTests(unittest.TestCase):
                         throttled.monitor(StopAfterWait(), 1)
 
         self.assertTrue(any('CORE: -50.00 mV' in call.args[0] for call in log.call_args_list))
-
-    def test_monitor_propagates_undervolt_read_errors(self):
-        throttled = load_throttled()
-        error = OSError('transient MSR read failure')
-
-        with mock.patch.object(throttled, 'readmsr', return_value=0):
-            with mock.patch.object(throttled, 'get_undervolt', side_effect=error):
-                with self.assertRaisesRegex(OSError, 'transient MSR read failure'):
-                    throttled.monitor(StopAfterWait(), 1)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_hwp_per_cpu.py
+++ b/tests/test_hwp_per_cpu.py
@@ -123,9 +123,10 @@ class HWPPerCpuTests(unittest.TestCase):
             return 0x1234
 
         with mock.patch.object(throttled, 'get_undervolt', return_value={'CORE': 0}):
-            with mock.patch.object(throttled, 'readmsr', side_effect=readmsr):
-                with mock.patch.object(throttled, 'writemsr') as writemsr:
-                    throttled.test_msr_rw_capabilities()
+            with mock.patch.object(throttled, 'get_icc_max', return_value={'CORE': 0}):
+                with mock.patch.object(throttled, 'readmsr', side_effect=readmsr):
+                    with mock.patch.object(throttled, 'writemsr') as writemsr:
+                        throttled.test_msr_rw_capabilities()
 
         writemsr.assert_called_once_with('IA32_HWP_REQUEST', 0x1234, cpu=0)
 

--- a/throttled.py
+++ b/throttled.py
@@ -719,6 +719,8 @@ def get_icc_max(plane=None, convert=False):
 
 def set_icc_max(config, source=None):
     """Apply the IccMax limits from the config to all current planes."""
+    if 'ICCMAX' in UNSUPPORTED_FEATURES:
+        return
     source = source or power['source']
     section = f'ICCMAX.{source}'
     for plane in CURRENT_PLANES:
@@ -1214,7 +1216,7 @@ def check_cpu():
 
 
 def test_msr_rw_capabilities():
-    """Probe undervolt and HWP support; mark unavailable features as such."""
+    """Probe undervolt, IccMax and HWP support; mark unavailable features as such."""
     global TESTMSR
     TESTMSR = True
     try:
@@ -1224,6 +1226,13 @@ def test_msr_rw_capabilities():
         except (IOError, OSError):
             warning('Undervolt seems not to be supported by your system, disabling.')
             UNSUPPORTED_FEATURES.append('UNDERVOLT')
+
+        try:
+            log('[I] Testing if IccMax is supported...')
+            get_icc_max()
+        except (IOError, OSError):
+            warning('IccMax seems not to be supported by your system, disabling.')
+            UNSUPPORTED_FEATURES.append('ICCMAX')
 
         try:
             log('[I] Testing if HWP is supported...')
@@ -1254,14 +1263,15 @@ def monitor(exit_event, wait):
     }
 
     if 'UNDERVOLT' in UNSUPPORTED_FEATURES:
-        # both readers use the OC mailbox (MSR 0x150), so IccMax is unreadable too
         log('[D] Undervolt offsets: unsupported')
-        log('[D] IccMax: unsupported')
     else:
         undervolt_values = get_undervolt(convert=True)
         undervolt_output = ' | '.join(f'{plane:s}: {undervolt_values[plane]:.2f} mV' for plane in VOLTAGE_PLANES)
         log(f'[D] Undervolt offsets: {undervolt_output:s}')
 
+    if 'ICCMAX' in UNSUPPORTED_FEATURES:
+        log('[D] IccMax: unsupported')
+    else:
         iccmax_values = get_icc_max(convert=True)
         iccmax_output = ' | '.join(f'{plane:s}: {iccmax_values[plane]:.2f} A' for plane in CURRENT_PLANES)
         log(f'[D] IccMax: {iccmax_output:s}')

--- a/throttled.py
+++ b/throttled.py
@@ -1254,15 +1254,17 @@ def monitor(exit_event, wait):
     }
 
     if 'UNDERVOLT' in UNSUPPORTED_FEATURES:
-        undervolt_output = 'N/A (unsupported)'
+        # both readers use the OC mailbox (MSR 0x150), so IccMax is unreadable too
+        log('[D] Undervolt offsets: unsupported')
+        log('[D] IccMax: unsupported')
     else:
         undervolt_values = get_undervolt(convert=True)
         undervolt_output = ' | '.join(f'{plane:s}: {undervolt_values[plane]:.2f} mV' for plane in VOLTAGE_PLANES)
-    log(f'[D] Undervolt offsets: {undervolt_output:s}')
+        log(f'[D] Undervolt offsets: {undervolt_output:s}')
 
-    iccmax_values = get_icc_max(convert=True)
-    iccmax_output = ' | '.join(f'{plane:s}: {iccmax_values[plane]:.2f} A' for plane in CURRENT_PLANES)
-    log(f'[D] IccMax: {iccmax_output:s}')
+        iccmax_values = get_icc_max(convert=True)
+        iccmax_output = ' | '.join(f'{plane:s}: {iccmax_values[plane]:.2f} A' for plane in CURRENT_PLANES)
+        log(f'[D] IccMax: {iccmax_output:s}')
 
     log('[D] Realtime monitoring of throttling causes:\n')
     while not exit_event.is_set():

--- a/throttled.py
+++ b/throttled.py
@@ -1253,8 +1253,11 @@ def monitor(exit_event, wait):
         'DRAM': (readmsr('MSR_DRAM_ENERGY_STATUS', cpu=0) * rapl_power_unit, time()),
     }
 
-    undervolt_values = get_undervolt(convert=True)
-    undervolt_output = ' | '.join(f'{plane:s}: {undervolt_values[plane]:.2f} mV' for plane in VOLTAGE_PLANES)
+    if 'UNDERVOLT' in UNSUPPORTED_FEATURES:
+        undervolt_output = 'N/A (unsupported)'
+    else:
+        undervolt_values = get_undervolt(convert=True)
+        undervolt_output = ' | '.join(f'{plane:s}: {undervolt_values[plane]:.2f} mV' for plane in VOLTAGE_PLANES)
     log(f'[D] Undervolt offsets: {undervolt_output:s}')
 
     iccmax_values = get_icc_max(convert=True)


### PR DESCRIPTION
## Summary

`throttled --monitor` crashes with `TypeError: 'int' object is not subscriptable` when undervolting is unsupported: `get_undervolt()` returns the scalar `0` and `monitor()` indexes it by plane. The monitor now prints `unsupported` instead.

The follow-up commit extends the guard to the IccMax read in the same preamble: `get_icc_max()` uses the same OC mailbox (MSR 0x150), and with only the undervolt read guarded the monitor went on to an unguarded `fatal()` that killed the whole daemon on exactly this hardware.

Supported systems keep the existing per-plane output unchanged.

Prepared with assistance from OpenAI Codex.
