### PR TITLE
Validate IccMax field encodings

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -74,7 +74,8 @@ class ConfigValidationTests(unittest.TestCase):
     def test_load_config_rejects_iccmax_values_that_overflow_the_field(self):
         throttled = load_throttled()
         throttled.args.config = self.write_config(
-            '[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n[ICCMAX.AC]\nCORE: 300\nGPU: 100\n'
+            '[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n'
+            '[ICCMAX.AC]\nCORE: 300\nGPU: 100\nCACHE: nan\n[ICCMAX.BATTERY]\nCORE: 0.1\n'
         )
 
         with mock.patch.object(throttled, 'warning'):
@@ -82,6 +83,8 @@ class ConfigValidationTests(unittest.TestCase):
 
         self.assertFalse(config.has_option('ICCMAX.AC', 'CORE'))
         self.assertEqual(config.getfloat('ICCMAX.AC', 'GPU'), 100)
+        self.assertFalse(config.has_option('ICCMAX.AC', 'CACHE'))
+        self.assertFalse(config.has_option('ICCMAX.BATTERY', 'CORE'))
 
     def test_mchbar_probe_keeps_setpci_stderr_out_of_the_journal(self):
         throttled = load_throttled()

--- a/tests/test_msr_encoding.py
+++ b/tests/test_msr_encoding.py
@@ -1,6 +1,8 @@
 import configparser
 import importlib.util
 import io
+import subprocess
+import sys
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
@@ -74,7 +76,7 @@ class MsrEncodingTests(unittest.TestCase):
         throttled = load_throttled()
 
         self.assertEqual(throttled.calc_icc_max_msr('CORE', 0x3FF / 4) & 0x3FF, 0x3FF)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             throttled.calc_icc_max_msr('CORE', 256)
 
     def test_package_power_limit_encoder_rejects_field_spill(self):
@@ -123,6 +125,31 @@ class MsrEncodingTests(unittest.TestCase):
                                 throttled.calc_reg_values(platform_info, config)
 
         self.assertIn('PL1', stderr.getvalue())
+
+    def test_icc_max_encoder_rejects_malformed_planes_and_currents(self):
+        throttled = load_throttled()
+
+        self.assertEqual(throttled.calc_icc_max_msr('CORE', 100) & 0x3FF, 400)
+        with self.assertRaisesRegex(ValueError, 'plane'):
+            throttled.calc_icc_max_msr('UNCORE', 100)
+        with self.assertRaisesRegex(ValueError, '10-bit'):
+            throttled.calc_icc_max_msr('CORE', 0.1)
+        for invalid in (0, -1, 255.76, float('nan'), float('inf'), 'abc'):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    throttled.calc_icc_max_msr('CORE', invalid)
+
+    def test_icc_max_validation_survives_python_optimize(self):
+        code = (
+            'import throttled\n'
+            'try:\n'
+            '    throttled.calc_icc_max_msr("CORE", 256)\n'
+            'except ValueError:\n'
+            '    raise SystemExit(0)\n'
+            'raise SystemExit(1)\n'
+        )
+        result = subprocess.run([sys.executable, '-O', '-c', code], cwd=ROOT, capture_output=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 if __name__ == '__main__':

--- a/throttled.py
+++ b/throttled.py
@@ -62,6 +62,8 @@ HWP_INTERVAL = 60
 UNDERVOLT_TICKS_PER_MV = 1.024
 UNDERVOLT_MIN_TICKS = -(1 << 10)
 UNDERVOLT_MAX_TICKS = 0
+ICCMAX_STEPS_PER_A = 4
+ICCMAX_MAX_FIELD = 0x3FF
 
 
 platform_info_bits = {
@@ -670,15 +672,28 @@ def undervolt(config, source=None):
             )
 
 
+def _icc_max_to_field(current):
+    """Convert an IccMax in A to the unsigned 10-bit quarter-ampere field."""
+    try:
+        current = float(current)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f'IccMax must be a number, got {current!r}.') from e
+    maximum_a = ICCMAX_MAX_FIELD / ICCMAX_STEPS_PER_A
+    if not math.isfinite(current) or not 0 < current <= maximum_a:
+        raise ValueError(f'IccMax must be between 0 (exclusive) and {maximum_a:g} A, got {current!r}.')
+    field = int(round(current * ICCMAX_STEPS_PER_A))
+    if not 1 <= field <= ICCMAX_MAX_FIELD:
+        raise ValueError(f'IccMax {current!r} A rounds outside the unsigned 10-bit field.')
+    return field
+
+
 def calc_icc_max_msr(plane, current):
     """Return the value to be written in the MSR 150h for setting the given
     IccMax (in A) to the given current plane.
     """
-    # the MSR field is 10 bits of 1/4 A steps: max 0x3FF / 4 = 255.75 A
-    assert 0 < current <= 0x3FF / 4
-    assert plane in CURRENT_PLANES
-    current = int(round(current * 4))
-    return 0x8000001700000000 | (CURRENT_PLANES[plane] << 40) | current
+    if plane not in CURRENT_PLANES:
+        raise ValueError(f'Unknown current plane: {plane!r}.')
+    return 0x8000001700000000 | (CURRENT_PLANES[plane] << 40) | _icc_max_to_field(current)
 
 
 def calc_icc_max_amp(msr_value):
@@ -826,12 +841,10 @@ def load_config():
             if key in config:
                 try:
                     value = config.getfloat(key, plane)
-                    # the MSR field holds 10 bits of 1/4 A steps: max 255.75 A
-                    if value <= 0 or value > 0x3FF / 4:
-                        raise ValueError
+                    _icc_max_to_field(value)
                     iccmax_enabled = True
-                except ValueError:
-                    warning(f'Invalid value for {plane:s} in {key:s}', oneshot=False)
+                except ValueError as e:
+                    warning(f'Invalid value for {plane:s} in {key:s}: {e}', oneshot=False)
                     config.remove_option(key, plane)
                 except configparser.NoOptionError:
                     pass


### PR DESCRIPTION
calc_icc_max_msr guarded its 10-bit quarter-ampere field with asserts, and python -O strips them: under -O, calc_icc_max_msr('CORE', 256) silently encoded field 0x0 into the mailbox write instead of failing. This moves the bounds into an _icc_max_to_field helper that raises ValueError, shared by the encoder and by the existing load_config validation (whose warning now says why a value was rejected), and adds a subprocess test that proves the check survives python -O.