### PR TITLE
mchbar: gate MMIO power-limit writes behind a host-bridge allowlist

### DIFF
--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -90,7 +90,7 @@ class ConfigProfileTests(unittest.TestCase):
 
         with mock.patch.object(throttled, 'read_mchbar_base', return_value=0):
             with mock.patch.object(throttled, 'MMIO'):
-                throttled.power_thread(state, exit_event, None)
+                throttled.power_thread(state, exit_event)
 
         self.assertEqual(exit_event.timeout, 5.0)
 

--- a/tests/test_daemon_robustness.py
+++ b/tests/test_daemon_robustness.py
@@ -52,7 +52,7 @@ class DaemonRobustnessTests(unittest.TestCase):
         with mock.patch.object(throttled, '_power_thread', side_effect=RuntimeError('boom')):
             with mock.patch.object(throttled.os, '_exit') as os_exit:
                 with mock.patch.object(throttled, 'warning'):
-                    throttled.power_thread({}, None, None)
+                    throttled.power_thread({}, None)
 
         os_exit.assert_called_once_with(1)
 

--- a/tests/test_enabled_barrier.py
+++ b/tests/test_enabled_barrier.py
@@ -113,7 +113,7 @@ class EnabledBarrierTests(unittest.TestCase):
                                     with mock.patch.object(
                                         throttled, 'get_reset_thermal_status'
                                     ) as thermal_status:
-                                        throttled._power_thread(state, StopAfterWait(), (6, 158, 13))
+                                        throttled._power_thread(state, StopAfterWait())
 
         writemsr.assert_not_called()
         undervolt.assert_not_called()
@@ -159,7 +159,7 @@ class EnabledBarrierTests(unittest.TestCase):
                         with mock.patch.object(
                             throttled, 'reload_config', return_value=(new_config, defaultdict(dict))
                         ):
-                            throttled._power_thread(state, StopAfterWait(), (6, 158, 13))
+                            throttled._power_thread(state, StopAfterWait())
 
         self.assertEqual(published, [True, True])
         self.assertIs(state['config'], new_config)

--- a/tests/test_power_source_flip.py
+++ b/tests/test_power_source_flip.py
@@ -98,7 +98,7 @@ class PowerSourceFlipTests(unittest.TestCase):
                     with mock.patch.object(throttled, 'undervolt', lambda config, source=None: calls.append(('undervolt', source))):
                         with mock.patch.object(throttled, 'set_icc_max', lambda config, source=None: calls.append(('iccmax', source))):
                             with mock.patch.object(throttled, 'log'):
-                                throttled.power_thread(state, StopAfterWait(), None)
+                                throttled.power_thread(state, StopAfterWait())
 
         self.assertEqual(calls, [('undervolt', 'AC'), ('iccmax', 'AC')])
         self.assertEqual(throttled.power['source'], 'AC')

--- a/tests/test_pr394_fixes.py
+++ b/tests/test_pr394_fixes.py
@@ -122,13 +122,260 @@ class PR394FixTests(unittest.TestCase):
 
         self.assertEqual(dict(regs), {})
 
-    def test_mchbar_reader_rejects_invalid_setpci_values_before_guessing(self):
+    def test_mchbar_allowlist_is_keyed_by_pci_device_and_covers_each_sourced_group(self):
+        throttled = load_throttled()
+        expected = {
+            0x5914: throttled.MCHBAR_ADDRESS_MASK_39_15,  # T480/T480s/X1C6
+            0x3EC4: throttled.MCHBAR_ADDRESS_MASK_39_15,  # P53
+            0x9A14: throttled.MCHBAR_ADDRESS_MASK_39_17,  # Tiger Lake
+            0x4601: throttled.MCHBAR_ADDRESS_MASK_42_17,  # Alder Lake
+            0xA706: throttled.MCHBAR_ADDRESS_MASK_42_17,  # Raptor Lake
+            0x7D21: throttled.MCHBAR_ADDRESS_MASK_42_17,  # Meteor Lake
+            0x7D06: throttled.MCHBAR_ADDRESS_MASK_42_17,  # Arrow Lake
+        }
+
+        for device_id, layout in expected.items():
+            with self.subTest(device_id=device_id):
+                self.assertEqual(throttled.MCHBAR_ADDRESS_MASKS_BY_PCI_DEVICE[device_id], layout)
+
+        self.assertTrue(all(isinstance(device_id, int) for device_id in throttled.MCHBAR_ADDRESS_MASKS_BY_PCI_DEVICE))
+
+    def test_host_bridge_identity_is_read_strictly_from_sysfs(self):
+        throttled = load_throttled()
+        self.assertEqual(throttled.PCI_HOST_BRIDGE_SYSFS_PATH, '/sys/bus/pci/devices/0000:00:00.0')
+        contents = {
+            f'{throttled.PCI_HOST_BRIDGE_SYSFS_PATH}/vendor': '0x8086\n',
+            f'{throttled.PCI_HOST_BRIDGE_SYSFS_PATH}/device': '0x5914\n',
+        }
+
+        def sysfs_open(path, encoding):
+            self.assertEqual(encoding, 'ascii')
+            return mock.mock_open(read_data=contents[path])()
+
+        with mock.patch('builtins.open', side_effect=sysfs_open):
+            self.assertEqual(throttled._read_host_bridge_identity(), (0x8086, 0x5914))
+
+    def test_host_bridge_parse_errors_fail_before_any_bar_probe(self):
         throttled = load_throttled()
 
-        with mock.patch.object(throttled, '_read_mchbar_dword', side_effect=[0xFFFFFFFF, 0xFED10001]) as read:
-            self.assertEqual(throttled.read_mchbar_base((6, 142, 9)), 0xFED10001)
+        for values in (('8086\n', '0x5914\n'), ('0x8086\n', '0x591\n'), ('0x8086\n', 'not-hex\n')):
+            with self.subTest(values=values):
+                handles = tuple(mock.mock_open(read_data=value)() for value in values)
+                with mock.patch('builtins.open', side_effect=handles):
+                    with mock.patch.object(throttled, '_read_mchbar_dword') as read:
+                        with mock.patch.object(throttled, 'warning'):
+                            self.assertIsNone(throttled.read_mchbar_base())
+                read.assert_not_called()
 
-        self.assertEqual([call.args[0] for call in read.call_args_list], ['ecam', None])
+        # only the strict regex rejects these: int() would accept both and the
+        # second would land on an allowlisted device id
+        for raw in ('0X5914\n', '0x05914\n'):
+            with self.subTest(raw=raw):
+                handles = (mock.mock_open(read_data='0x8086\n')(), mock.mock_open(read_data=raw)())
+                with mock.patch('builtins.open', side_effect=handles):
+                    self.assertIsNone(throttled._read_host_bridge_identity())
+
+        with mock.patch('builtins.open', side_effect=PermissionError('denied')):
+            with mock.patch.object(throttled, '_read_mchbar_dword') as read:
+                with mock.patch.object(throttled, 'warning'):
+                    self.assertIsNone(throttled.read_mchbar_base())
+        read.assert_not_called()
+
+    def test_mchbar_reader_combines_modern_dwords_above_four_gib(self):
+        throttled = load_throttled()
+        values = {'48.l': b'fedc0001\n', '4c.l': b'00000001\n'}
+
+        def setpci(cmd, stderr):
+            self.assertIs(stderr, throttled.PIPE)
+            return values[cmd[-1]]
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0xA706)):
+            with mock.patch.object(throttled, 'check_output', side_effect=setpci) as check:
+                self.assertEqual(throttled.read_mchbar_base(), 0x1FEDC0000)
+
+        self.assertEqual([call.args[0][-1] for call in check.call_args_list], ['48.l', '4c.l'])
+
+    def test_mchbar_reader_accepts_the_p53_coffee_lake_host_bridge(self):
+        throttled = load_throttled()
+        values = {'48.l': b'fed10001\n', '4c.l': b'00000000\n'}
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0x3EC4)):
+            with mock.patch.object(throttled, 'check_output', side_effect=lambda cmd, stderr: values[cmd[-1]]):
+                self.assertEqual(throttled.read_mchbar_base(), 0xFED10000)
+
+    def test_mchbar_reader_accepts_a_low_nonzero_32k_bar(self):
+        throttled = load_throttled()
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0x3EC4)):
+            with mock.patch.object(throttled, '_read_mchbar_dword', side_effect=(0x8001, 0)):
+                self.assertEqual(throttled.read_mchbar_base(), 0x8000)
+
+    def test_mchbar_reader_validates_the_tiger_lake_128k_layout(self):
+        throttled = load_throttled()
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0x9A14)):
+            with mock.patch.object(throttled, '_read_mchbar_dword', side_effect=(0x20001, 0)):
+                self.assertEqual(throttled.read_mchbar_base(), 0x20000)
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0x9A14)):
+            with mock.patch.object(throttled, '_read_mchbar_dword', side_effect=(0x30001, 0) * 2):
+                with mock.patch.object(throttled, 'warning'):
+                    self.assertIsNone(throttled.read_mchbar_base())
+
+    def test_mchbar_reader_rejects_disabled_zero_and_reserved_bit_bars(self):
+        throttled = load_throttled()
+        invalid_values = (
+            (0xA706, 0xFEDC0000, 0),
+            (0xA706, 0x00000001, 0),
+            (0xA706, 0xFED1F001, 0),
+            (0xA706, 0xFEDC0001, 0x400),
+            (0x3EC4, 0xFED14001, 0),
+        )
+
+        for device_id, low, high in invalid_values:
+            with self.subTest(device_id=device_id, low=low, high=high):
+                reads = (low, high, low, high)
+                with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, device_id)):
+                    with mock.patch.object(throttled, '_read_mchbar_dword', side_effect=reads):
+                        with mock.patch.object(throttled, 'warning') as warning:
+                            self.assertIsNone(throttled.read_mchbar_base())
+
+                warning.assert_called_once()
+                self.assertIn('disabling only MMIO', warning.call_args.args[0])
+
+    def test_mchbar_reader_accepts_a_42_bit_base_above_the_39_bit_range(self):
+        throttled = load_throttled()
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0xA706)):
+            with mock.patch.object(throttled, '_read_mchbar_dword', side_effect=(0x00000001, 0x80)):
+                self.assertEqual(throttled.read_mchbar_base(), 1 << 39)
+
+    def test_mchbar_reader_rejects_wrong_vendor_and_unknown_device_without_probing(self):
+        throttled = load_throttled()
+
+        for identity in ((0x1234, 0x5914), (0x8086, 0xFFFF)):
+            with self.subTest(identity=identity):
+                with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=identity):
+                    with mock.patch.object(throttled, '_read_mchbar_dword') as read:
+                        with mock.patch.object(throttled, 'warning') as warning:
+                            self.assertIsNone(throttled.read_mchbar_base())
+
+                read.assert_not_called()
+                warning.assert_called_once()
+
+    def test_power_thread_gates_mmio_on_the_pci_identity(self):
+        throttled = load_throttled()
+        config = make_config()
+        state = {'config': config, 'regs': {'AC': {'MSR_PKG_POWER_LIMIT': 0x1234}, 'BATTERY': {}}}
+        mapping = mock.Mock()
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0x5914)):
+            with mock.patch.object(throttled, '_read_mchbar_dword', side_effect=(0xFED10001, 0)):
+                with mock.patch.object(throttled, 'MMIO', return_value=mapping) as mmio:
+                    with mock.patch.object(throttled, 'writemsr'):
+                        throttled._power_thread(state, StopAfterWait())
+
+        mmio.assert_called_once_with(0xFED159A0, 8)
+        mapping.write64.assert_called_once_with(0, 0x1234)
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0xFFFF)):
+            with mock.patch.object(throttled, '_read_mchbar_dword') as read:
+                with mock.patch.object(throttled, 'MMIO') as mmio:
+                    with mock.patch.object(throttled, 'writemsr') as writemsr:
+                        with mock.patch.object(throttled, 'warning'):
+                            throttled._power_thread(state, StopAfterWait())
+
+        read.assert_not_called()
+        mmio.assert_not_called()
+        writemsr.assert_called_once_with('MSR_PKG_POWER_LIMIT', 0x1234)
+
+    def test_mchbar_reader_retries_a_complete_pair_after_either_ecam_read_fails(self):
+        throttled = load_throttled()
+        values = {'48.l': b'fedc0001\n', '4c.l': b'00000001\n'}
+
+        for failed_register in values:
+            with self.subTest(failed_register=failed_register):
+
+                def setpci(cmd, stderr):
+                    self.assertIs(stderr, throttled.PIPE)
+                    if '-A' in cmd and cmd[-1] == failed_register:
+                        raise throttled.CalledProcessError(1, cmd, stderr=b'blocked')
+                    return values[cmd[-1]]
+
+                with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0xA706)):
+                    with mock.patch.object(throttled, 'check_output', side_effect=setpci) as check:
+                        self.assertEqual(throttled.read_mchbar_base(), 0x1FEDC0000)
+
+                commands = [call.args[0] for call in check.call_args_list]
+                self.assertEqual([command[-1] for command in commands], ['48.l', '4c.l', '48.l', '4c.l'])
+                self.assertEqual(['-A' in command for command in commands], [True, True, False, False])
+                for command in commands:
+                    self.assertEqual(command[command.index('-s') + 1], '0000:00:00.0')
+
+    def test_mchbar_reader_rejects_invalid_setpci_output_and_execution_errors(self):
+        throttled = load_throttled()
+
+        for output in (b'1\n', b'0xfedc0001\n', b'not-a-hex-dword\n', b'100000000\n'):
+            with self.subTest(output=output):
+                with mock.patch.object(throttled, 'check_output', return_value=output):
+                    self.assertIsNone(throttled._read_mchbar_dword('ecam'))
+
+        errors = (
+            PermissionError('denied'),
+            throttled.CalledProcessError(1, ('setpci',), stderr=b'blocked'),
+        )
+        for error in errors:
+            with self.subTest(error=error):
+                with mock.patch.object(throttled, 'check_output', side_effect=error):
+                    self.assertIsNone(throttled._read_mchbar_dword('ecam'))
+
+    def test_invalid_mchbar_never_opens_dev_mem_and_keeps_msr_writes(self):
+        throttled = load_throttled()
+        config = make_config()
+        state = {'config': config, 'regs': {'AC': {'MSR_PKG_POWER_LIMIT': 0x1234}, 'BATTERY': {}}}
+        values = {'48.l': b'fed1f001\n', '4c.l': b'00000000\n'}
+
+        with mock.patch.object(throttled, '_read_host_bridge_identity', return_value=(0x8086, 0xA706)):
+            with mock.patch.object(throttled, 'check_output', side_effect=lambda cmd, stderr: values[cmd[-1]]) as check:
+                with mock.patch.object(throttled, 'MMIO') as mmio:
+                    with mock.patch.object(throttled, 'writemsr') as writemsr:
+                        with mock.patch.object(throttled, 'warning'):
+                            throttled._power_thread(state, StopAfterWait())
+
+        self.assertEqual(check.call_count, 4)
+        mmio.assert_not_called()
+        writemsr.assert_called_once_with('MSR_PKG_POWER_LIMIT', 0x1234)
+
+    def test_mchbar_mapping_uses_the_clean_base_and_documented_offset(self):
+        throttled = load_throttled()
+        config = make_config()
+        state = {'config': config, 'regs': {'AC': {'MSR_PKG_POWER_LIMIT': 0x1234}, 'BATTERY': {}}}
+        mapping = mock.Mock()
+
+        with mock.patch.object(throttled, 'read_mchbar_base', return_value=0xFED10000):
+            with mock.patch.object(throttled, 'MMIO', return_value=mapping) as mmio:
+                with mock.patch.object(throttled, 'writemsr'):
+                    throttled._power_thread(state, StopAfterWait())
+
+        mmio.assert_called_once_with(0xFED159A0, 8)
+        mapping.write64.assert_called_once_with(0, 0x1234)
+
+    def test_mchbar_write_error_disables_only_the_mmio_path(self):
+        throttled = load_throttled()
+        config = make_config()
+        state = {'config': config, 'regs': {'AC': {'MSR_PKG_POWER_LIMIT': 0x1234}, 'BATTERY': {}}}
+        mapping = mock.Mock()
+        mapping.write64.side_effect = throttled.MMIOError('blocked')
+
+        with mock.patch.object(throttled, 'read_mchbar_base', return_value=0xFED10000):
+            with mock.patch.object(throttled, 'MMIO', return_value=mapping):
+                with mock.patch.object(throttled, 'writemsr') as writemsr:
+                    with mock.patch.object(throttled, 'warning') as warning:
+                        throttled._power_thread(state, StopAfterWait())
+
+        writemsr.assert_called_once_with('MSR_PKG_POWER_LIMIT', 0x1234)
+        mapping.write64.assert_called_once_with(0, 0x1234)
+        self.assertIn('disabling only MMIO writes', warning.call_args.args[0])
 
     def test_power_thread_autoreload_updates_shared_state_for_dbus_callbacks(self):
         throttled = load_throttled()
@@ -141,7 +388,7 @@ class PR394FixTests(unittest.TestCase):
             with mock.patch.object(throttled, 'MMIO'):
                 with mock.patch.object(throttled, 'get_config_write_time', side_effect=[1, 2]):
                     with mock.patch.object(throttled, 'reload_config', return_value=(new_config, new_regs)):
-                        throttled.power_thread(state, StopAfterWait(), None)
+                        throttled.power_thread(state, StopAfterWait())
 
         self.assertIs(state['config'], new_config)
         self.assertIs(state['regs'], new_regs)

--- a/throttled.py
+++ b/throttled.py
@@ -64,6 +64,17 @@ UNDERVOLT_MIN_TICKS = -(1 << 10)
 UNDERVOLT_MAX_TICKS = 0
 ICCMAX_STEPS_PER_A = 4
 ICCMAX_MAX_FIELD = 0x3FF
+MCHBAR_ENABLE_BIT = 1
+MCHBAR_PACKAGE_POWER_LIMIT_OFFSET = 0x59A0
+MCHBAR_PACKAGE_POWER_LIMIT_SIZE = 8
+PCI_HOST_BRIDGE_SYSFS_PATH = '/sys/bus/pci/devices/0000:00:00.0'
+PCI_VENDOR_ID_INTEL = 0x8086
+# The masked address bits also encode the per-generation window alignment, so
+# rejecting any bit outside the mask fully validates the BAR before /dev/mem
+# is ever opened.
+MCHBAR_ADDRESS_MASK_39_15 = ((1 << 39) - 1) & ~((1 << 15) - 1)
+MCHBAR_ADDRESS_MASK_39_17 = ((1 << 39) - 1) & ~((1 << 17) - 1)
+MCHBAR_ADDRESS_MASK_42_17 = ((1 << 42) - 1) & ~((1 << 17) - 1)
 
 
 platform_info_bits = {
@@ -193,6 +204,55 @@ supported_cpus = {
     (6, 189, 1): 'LunarLake',
     (6, 190, 0): 'AlderLake-N',
     (6, 198, 2): 'ArrowLake-HX',
+}
+
+# MCHBAR belongs to the PCI host bridge, not to a CPUID signature. This is a
+# deliberately narrow allowlist: an unlisted device remains MSR-only.
+#
+# TGL/ADL/RPL/Core Ultra datasheets document PACKAGE_RAPL_LIMIT_0_0_0_MCHBAR_PCU
+# at MCHBAR + 0x59a0 (Intel docs 631122, 767625/767626, 764981/767624, 795258,
+# 819323, 844345). Kaby and Coffee Lake do not publish the offset: those two
+# rest on coreboot's MCH_PKG_POWER_LIMIT_LO (the MSR 0x610 mirror) and a live
+# MMIO == MSR equality check on 0x3ec4. Groups follow Linux igen6/ie31200 EDAC.
+MCHBAR_ADDRESS_MASKS_BY_PCI_DEVICE = {
+    # Kaby Lake-U/R and Coffee Lake-H target systems (T480/T480s/X1C6, P53).
+    0x5914: MCHBAR_ADDRESS_MASK_39_15,
+    0x3EC4: MCHBAR_ADDRESS_MASK_39_15,
+    # Tiger Lake (Linux igen6 tgl_cfg).
+    0x9A14: MCHBAR_ADDRESS_MASK_39_17,
+    # Alder Lake (Linux igen6 adl_cfg).
+    0x4601: MCHBAR_ADDRESS_MASK_42_17,
+    0x4602: MCHBAR_ADDRESS_MASK_42_17,
+    0x4621: MCHBAR_ADDRESS_MASK_42_17,
+    0x4641: MCHBAR_ADDRESS_MASK_42_17,
+    # Alder/Raptor Lake S/HX (Linux ie31200 rpl_s_cfg).
+    0x4660: MCHBAR_ADDRESS_MASK_42_17,
+    0x4668: MCHBAR_ADDRESS_MASK_42_17,
+    0x4648: MCHBAR_ADDRESS_MASK_42_17,
+    0xA703: MCHBAR_ADDRESS_MASK_42_17,
+    0x4640: MCHBAR_ADDRESS_MASK_42_17,
+    0x4630: MCHBAR_ADDRESS_MASK_42_17,
+    0xA700: MCHBAR_ADDRESS_MASK_42_17,
+    0xA740: MCHBAR_ADDRESS_MASK_42_17,
+    0xA704: MCHBAR_ADDRESS_MASK_42_17,
+    0xA702: MCHBAR_ADDRESS_MASK_42_17,
+    # Raptor Lake-P (Linux igen6 rpl_p_cfg).
+    0xA706: MCHBAR_ADDRESS_MASK_42_17,
+    0xA707: MCHBAR_ADDRESS_MASK_42_17,
+    0xA708: MCHBAR_ADDRESS_MASK_42_17,
+    0xA716: MCHBAR_ADDRESS_MASK_42_17,
+    0xA718: MCHBAR_ADDRESS_MASK_42_17,
+    # Meteor Lake and Arrow Lake-U/H (Linux igen6 mtl_ps/mtl_p_cfg).
+    0x7D21: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D22: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D23: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D24: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D01: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D02: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D14: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D06: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D20: MCHBAR_ADDRESS_MASK_42_17,
+    0x7D30: MCHBAR_ADDRESS_MASK_42_17,
 }
 
 TESTMSR = False
@@ -994,48 +1054,89 @@ def reload_config():
     return config, regs
 
 
-def _read_mchbar_dword(method=None):
-    """Read MCHBAR PCI config register 0x48 for device 0:0.0."""
-    cmd = ['setpci', '-s', '0:0.0', '48.l']
+def _read_mchbar_dword(method=None, register='48.l'):
+    """Read one MCHBAR PCI config DWORD for device 0:0.0."""
+    cmd = ['setpci', '-s', '0000:00:00.0', register]
     if method:
         cmd[1:1] = ['-A', method]
     try:
         # capture stderr: a probe method is allowed to fail (e.g. the ECAM
         # region is not mappable under STRICT_DEVMEM) and its complaint must
         # not leak to the journal; read_mchbar_base() warns if all methods fail
-        return int(check_output(cmd, stderr=PIPE), 16)
+        raw_value = check_output(cmd, stderr=PIPE).strip()
+        if re.fullmatch(rb'[0-9a-fA-F]{8}', raw_value) is None:
+            return None
+        return int(raw_value, 16)
     except CalledProcessError as e:
         if args.debug:
-            err = e.stderr.decode(errors='replace').strip()
+            err = (e.stderr or b'').decode(errors='replace').strip()
             log(f'[D] MCHBAR - setpci {method or "default"} probe failed: {err}')
         return None
-    except (FileNotFoundError, ValueError):
+    except OSError:
         return None
 
 
-def read_mchbar_base(cpuid):
-    """Return the enabled MCHBAR base, falling back to a CPUID-based guess."""
+def _read_host_bridge_identity():
+    """Return the D0:F0 PCI vendor/device IDs from sysfs, or None."""
+    values = []
+    for attribute in ('vendor', 'device'):
+        try:
+            with open(os.path.join(PCI_HOST_BRIDGE_SYSFS_PATH, attribute), encoding='ascii') as attribute_file:
+                raw_value = attribute_file.read().strip()
+            if re.fullmatch(r'0x[0-9a-fA-F]{4}', raw_value) is None:
+                return None
+            values.append(int(raw_value[2:], 16))
+        except (OSError, UnicodeDecodeError):
+            return None
+    return tuple(values)
+
+
+def read_mchbar_base():
+    """Return a validated enabled 64-bit MCHBAR base, or None."""
+    identity = _read_host_bridge_identity()
+    if identity is None:
+        warning('Could not identify the PCI host bridge; disabling only MMIO package power-limit writes.')
+        return None
+
+    vendor_id, device_id = identity
+    if vendor_id != PCI_VENDOR_ID_INTEL:
+        warning(
+            f'PCI host bridge vendor {vendor_id:#06x} is not Intel; disabling only MMIO package power-limit writes.'
+        )
+        return None
+
+    address_mask = MCHBAR_ADDRESS_MASKS_BY_PCI_DEVICE.get(device_id)
+    if address_mask is None:
+        warning(
+            f'Unknown Intel PCI host bridge device {device_id:#06x}; '
+            f'disabling only MMIO package power-limit writes.'
+        )
+        return None
+
+    allowed_mask = address_mask | MCHBAR_ENABLE_BIT
     for method in ('ecam', None):
-        base = _read_mchbar_dword(method)
-        if base is not None and base not in (0, 0xFFFFFFFF) and base & 1:
+        low = _read_mchbar_dword(method, '48.l')
+        high = _read_mchbar_dword(method, '4c.l')
+        if low is None or high is None:
+            continue
+        mchbar = low | (high << 32)
+        if not mchbar & MCHBAR_ENABLE_BIT or mchbar & ~allowed_mask:
+            continue
+        base = mchbar & address_mask
+        if base != 0:
             return base
 
-    warning(
-        'Could not read a valid MCHBAR base via setpci. This is typically provided by the "pciutils" package.'
-    )
-    warning('Trying to guess the MCHBAR address from the CPUID. This MIGHT NOT WORK!')
-    if cpuid in ((6, 140, 1), (6, 140, 2), (6, 141, 1), (6, 151, 2), (6, 151, 5), (6, 154, 3), (6, 154, 4)):
-        return 0xFEDC0001
-    return 0xFED10001
+    warning('Could not read a valid enabled MCHBAR base via setpci; disabling only MMIO package power-limit writes.')
+    return None
 
 
-def power_thread(state, exit_event, cpuid):
+def power_thread(state, exit_event):
     """Crash-loud wrapper for _power_thread: an uncaught exception (or a
     sys.exit() from a helper) would only kill this thread, leaving a zombie
     daemon that looks healthy to systemd while no longer touching the hardware.
     """
     try:
-        _power_thread(state, exit_event, cpuid)
+        _power_thread(state, exit_event)
     except Exception:
         warning(f'power thread crashed:\n{traceback.format_exc()}', oneshot=False)
         if args.log:
@@ -1043,16 +1144,23 @@ def power_thread(state, exit_event, cpuid):
         os._exit(1)
 
 
-def _power_thread(state, exit_event, cpuid):
+def _power_thread(state, exit_event):
     """Daemon main loop: periodically (re-)apply throttling MSRs."""
     config, regs = state['config'], state['regs']
-    mchbar_base = read_mchbar_base(cpuid)
-    try:
-        mchbar_mmio = MMIO(mchbar_base + 0x599F, 8)
-    except MMIOError:
-        warning('Unable to open /dev/mem. TDP override might not work correctly.')
-        warning('Check CONFIG_DEVMEM=y and that kernel lockdown is disabled (CONFIG_IO_STRICT_DEVMEM can also block this region).')
-        mchbar_mmio = None
+    mchbar_base = read_mchbar_base()
+    mchbar_mmio = None
+    if mchbar_base is not None:
+        try:
+            mchbar_mmio = MMIO(
+                mchbar_base + MCHBAR_PACKAGE_POWER_LIMIT_OFFSET,
+                MCHBAR_PACKAGE_POWER_LIMIT_SIZE,
+            )
+        except MMIOError:
+            warning('Unable to open /dev/mem. MMIO package power-limit writes are disabled.')
+            warning(
+                'Check CONFIG_DEVMEM=y and that kernel lockdown is disabled '
+                '(CONFIG_IO_STRICT_DEVMEM can also block this region).'
+            )
 
     next_hwp_write = 0
     applied_source = power['source']
@@ -1132,13 +1240,17 @@ def _power_thread(state, exit_event, cpuid):
                 log(f'[D] MSR PACKAGE_POWER_LIMIT - write {write_value:#x} - read {read_value:#x} - match {match}')
             if mchbar_mmio is not None:
                 # set MCHBAR register to the same PL1/2 values
-                mchbar_mmio.write64(0, write_value)
-                if args.debug:
-                    read_value = mchbar_mmio.read64(0)
-                    match = OK if write_value == read_value else ERR
-                    log(
-                        f'[D] MCHBAR PACKAGE_POWER_LIMIT - write {write_value:#x} - read {read_value:#x} - match {match}'
-                    )
+                try:
+                    mchbar_mmio.write64(0, write_value)
+                    if args.debug:
+                        read_value = mchbar_mmio.read64(0)
+                        match = OK if write_value == read_value else ERR
+                        log(
+                            f'[D] MCHBAR PACKAGE_POWER_LIMIT - write {write_value:#x} - read {read_value:#x} - match {match}'
+                        )
+                except OSError as e:
+                    warning(f'Unable to write MCHBAR package power limits ({e}); disabling only MMIO writes.')
+                    mchbar_mmio = None
 
         # Disable BDPROCHOT
         disable_bdprochot = config.getboolean(power_source, 'Disable_BDPROCHOT', fallback=None)
@@ -1360,10 +1472,9 @@ def main():
         log('[I] Throttled is disabled in config file... Quitting. :(')
         return
 
-    cpuid = None
     if not args.force:
         check_kernel()
-        cpuid = check_cpu()
+        check_cpu()
 
     set_msr_allow_writes()
 
@@ -1384,7 +1495,7 @@ def main():
     state = {'config': config, 'regs': regs}
 
     exit_event = Event()
-    thread = Thread(target=power_thread, args=(state, exit_event, cpuid))
+    thread = Thread(target=power_thread, args=(state, exit_event))
     thread.daemon = True
     thread.start()
 


### PR DESCRIPTION
Replaces the CPUID-based MCHBAR guess with an explicit PCI host-bridge gate: the D0:F0 vendor/device IDs are read from sysfs, the device is looked up in an allowlist of bridges whose PACKAGE_RAPL_LIMIT MMIO mirror is documented at MCHBAR + 0x59a0, and the 64-bit BAR is validated against the per-generation address mask (enable bit set, no bits outside the mask, non-zero base). Anything else falls back to MSR-only operation instead of mapping a guessed address through /dev/mem. The power thread no longer takes the CPUID: its only consumer was the guess.

Evidence per generation:
- TGL/ADL/RPL/Core Ultra: Intel documents `PACKAGE_RAPL_LIMIT_0_0_0_MCHBAR_PCU` at offset 0x59a0 (docs 631122, 767625/767626, 764981/767624, 795258, 819323, 844345).
- Kaby/Coffee Lake datasheets do not publish the offset; those two IDs rest on coreboot (`MCH_PKG_POWER_LIMIT_LO 0x59a0`, written as the MSR 0x610 mirror by the SoC that owns them) and on a live check on a ThinkPad P53 (0x3ec4): MMIO@MCHBAR+0x59a0 read back bit-identical to MSR 0x610.
- Device groups follow Linux `igen6_edac.c` / `ie31200_edac.c`.

Tested: full unit suite; live on the P53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)