### PR TITLE
config: disable malformed trip temperatures instead of crashing

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -309,6 +309,71 @@ class ConfigValidationTests(unittest.TestCase):
         self.assertFalse(any('shared_default' in message for message in messages))
         self.assertEqual(config.get('ICCMAX.AC', 'CORE'), '100')
 
+    def test_loader_removes_malformed_trip_temperatures(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[GENERAL]\nEnabled: True\n'
+            '[AC]\nUpdate_Rate_s: 5\nTrip_Temp_C: warm\n[BATTERY]\nUpdate_Rate_s: 5\nTrip_Temp_C: nan\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertFalse(config.has_option('AC', 'Trip_Temp_C'))
+        self.assertFalse(config.has_option('BATTERY', 'Trip_Temp_C'))
+        self.assertEqual(warning.call_count, 2)
+
+    def test_loader_removes_a_malformed_trip_temperature_inherited_from_default(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nTrip_Temp_C: warm\n[GENERAL]\nEnabled: True\n'
+            '[AC]\nUpdate_Rate_s: 5\n[BATTERY]\nUpdate_Rate_s: 5\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertIsNone(config.getfloat('AC', 'Trip_Temp_C', fallback=None))
+        self.assertIsNone(config.getfloat('BATTERY', 'Trip_Temp_C', fallback=None))
+        warning.assert_called_once()
+        self.assertIn('[DEFAULT]', warning.call_args.args[0])
+
+    def test_loader_removes_a_default_trip_temperature_masked_by_a_malformed_profile_value(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nTrip_Temp_C: nan\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\nTrip_Temp_C: warm\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertIsNone(config.getfloat('AC', 'Trip_Temp_C', fallback=None))
+        self.assertEqual(warning.call_count, 2)
+
+    def test_loader_removes_an_interpolation_breaking_trip_temperature(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\nTrip_Temp_C: 95%\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertIsNone(config.getfloat('AC', 'Trip_Temp_C', fallback=None))
+        warning.assert_called_once()
+
+    def test_loader_falls_back_to_a_valid_default_trip_temperature(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nTrip_Temp_C: 90\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\nTrip_Temp_C: warm\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertEqual(config.getfloat('AC', 'Trip_Temp_C'), 90.0)
+        warning.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/throttled.py
+++ b/throttled.py
@@ -850,7 +850,23 @@ def load_config():
             elif option == 'Update_Rate_s':
                 fatal(f'The mandatory "Update_Rate_s" parameter is missing in the [{power_source:s}] profile.')
 
-        trip_temp = config.getfloat(power_source, 'Trip_Temp_C', fallback=None)
+        trip_temp = None
+        # a malformed profile value may mask a second malformed value inherited from [DEFAULT]
+        for _ in range(2):
+            try:
+                trip_temp = config.getfloat(power_source, 'Trip_Temp_C', fallback=None)
+                if trip_temp is None or math.isfinite(trip_temp):
+                    break
+                raise ValueError(trip_temp)
+            except (ValueError, configparser.InterpolationError):
+                trip_temp = None
+                if config.remove_option(power_source, 'Trip_Temp_C'):
+                    section = power_source
+                else:
+                    # the value is inherited from [DEFAULT]: drop it there or it survives the removal
+                    section = config.default_section
+                    config.remove_option(section, 'Trip_Temp_C')
+                warning(f'Invalid "Trip_Temp_C" value in [{section:s}]: ignoring it.', oneshot=False)
         if trip_temp is not None:
             valid_trip_temp = min(TRIP_TEMP_RANGE[1], max(TRIP_TEMP_RANGE[0], trip_temp))
             if trip_temp != valid_trip_temp:


### PR DESCRIPTION
A non-numeric `Trip_Temp_C` makes `config.getfloat` raise ValueError and kills the loader at startup or on autoreload; a parseable non-finite value (`nan`/`inf`) slips into the clamp instead. Both cases now warn and drop the option, so the daemon keeps running with the trip temperature disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)