### PR TITLE
config: warn on unknown IccMax plane names

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -294,5 +294,21 @@ class ConfigValidationTests(unittest.TestCase):
         writemsr.assert_not_called()
 
 
+    def test_loader_warns_on_unknown_iccmax_plane_keys_but_not_default_keys(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nshared_default: 1\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n'
+            '[ICCMAX.AC]\nCORE: 100\nCORF: 110\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        messages = [call.args[0] for call in warning.call_args_list]
+        self.assertTrue(any('Unknown IccMax plane "corf"' in message for message in messages))
+        self.assertFalse(any('shared_default' in message for message in messages))
+        self.assertEqual(config.get('ICCMAX.AC', 'CORE'), '100')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/throttled.py
+++ b/throttled.py
@@ -837,6 +837,13 @@ def load_config():
     iccmax_enabled = False
     # check for invalid values (ie. <= 0 or > 0x3FF) in the IccMax settings
     for key in ICCMAX_KEYS:
+        if key not in config:
+            continue
+        for option in config[key]:
+            if option in config.defaults():
+                continue
+            if option.upper() not in CURRENT_PLANES:
+                warning(f'Unknown IccMax plane "{option:s}" in [{key:s}]: ignoring it.', oneshot=False)
         for plane in CURRENT_PLANES:
             if key in config:
                 try:


### PR DESCRIPTION
A typo in an `[ICCMAX*]` plane name is silently ignored: the loader only iterates the known planes, so the intended current limit is never applied and nothing tells the user. Warn on any unknown option (DEFAULT-section keys exempt) so the misconfiguration is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)