### PR TITLE
iccmax: quantise down so the ceiling never exceeds the configuration

### DIFF
--- a/tests/test_msr_encoding.py
+++ b/tests/test_msr_encoding.py
@@ -152,5 +152,16 @@ class MsrEncodingTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
 
 
+    def test_iccmax_encoder_floors_offgrid_values_to_the_configured_ceiling(self):
+        throttled = load_throttled()
+
+        # exact grid values encode unchanged
+        self.assertEqual(throttled.calc_icc_max_msr('CORE', 0.25) & 0x3FF, 1)
+        self.assertEqual(throttled.calc_icc_max_msr('CORE', 255.75) & 0x3FF, 0x3FF)
+        # off-grid values quantise DOWN, never above the configured ceiling
+        self.assertEqual(throttled.calc_icc_max_msr('CORE', 105.4) & 0x3FF, 421)
+        self.assertEqual(throttled.calc_icc_max_msr('CORE', 200.9) & 0x3FF, 803)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/throttled.py
+++ b/throttled.py
@@ -681,9 +681,10 @@ def _icc_max_to_field(current):
     maximum_a = ICCMAX_MAX_FIELD / ICCMAX_STEPS_PER_A
     if not math.isfinite(current) or not 0 < current <= maximum_a:
         raise ValueError(f'IccMax must be between 0 (exclusive) and {maximum_a:g} A, got {current!r}.')
-    field = int(round(current * ICCMAX_STEPS_PER_A))
+    # floor: quantisation must never enforce a ceiling above the configured one
+    field = int(current * ICCMAX_STEPS_PER_A)
     if not 1 <= field <= ICCMAX_MAX_FIELD:
-        raise ValueError(f'IccMax {current!r} A rounds outside the unsigned 10-bit field.')
+        raise ValueError(f'IccMax {current!r} A quantises outside the unsigned 10-bit field.')
     return field
 
 
@@ -756,7 +757,7 @@ def set_icc_max(config, source=None):
                     read_current_A = calc_icc_max_amp(read_value)
                     match = OK if write_value == read_value else ERR
                     log(
-                        f'[D] IccMax plane {plane:s} - write {write_current_amp:.2f} A ({write_value:#x}) - read {read_current_A:.2f} A ({read_value:#x}) - match {match}'
+                        f'[D] IccMax plane {plane:s} - write {calc_icc_max_amp(write_value):.2f} A ({write_value:#x}) - read {read_current_A:.2f} A ({read_value:#x}) - match {match}'
                     )
         except (configparser.NoSectionError, configparser.NoOptionError):
             pass


### PR DESCRIPTION
Rounding to the nearest 1/4 A step can encode a current limit up to 0.125 A above the configured value; truncating keeps the enforced ceiling at or below what the operator wrote. The debug line now logs the amperes actually encoded instead of the requested ones, so a quantised write no longer prints as a false mismatch against the read-back.

This deliberately revisits the rounding chosen in #408: for a protective limit, never-exceed seems the safer convention. Happy to drop it if you prefer rounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)