### PR TITLE
config: survive malformed values inherited from [DEFAULT]

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -309,6 +309,71 @@ class ConfigValidationTests(unittest.TestCase):
         self.assertFalse(any('shared_default' in message for message in messages))
         self.assertEqual(config.get('ICCMAX.AC', 'CORE'), '100')
 
+    def test_loader_removes_malformed_trip_temperatures(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[GENERAL]\nEnabled: True\n'
+            '[AC]\nUpdate_Rate_s: 5\nTrip_Temp_C: warm\n[BATTERY]\nUpdate_Rate_s: 5\nTrip_Temp_C: nan\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertFalse(config.has_option('AC', 'Trip_Temp_C'))
+        self.assertFalse(config.has_option('BATTERY', 'Trip_Temp_C'))
+        self.assertEqual(warning.call_count, 2)
+
+    def test_loader_removes_a_malformed_trip_temperature_inherited_from_default(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nTrip_Temp_C: warm\n[GENERAL]\nEnabled: True\n'
+            '[AC]\nUpdate_Rate_s: 5\n[BATTERY]\nUpdate_Rate_s: 5\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertIsNone(config.getfloat('AC', 'Trip_Temp_C', fallback=None))
+        self.assertIsNone(config.getfloat('BATTERY', 'Trip_Temp_C', fallback=None))
+        warning.assert_called_once()
+        self.assertIn('[DEFAULT]', warning.call_args.args[0])
+
+    def test_loader_removes_a_default_trip_temperature_masked_by_a_malformed_profile_value(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nTrip_Temp_C: nan\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\nTrip_Temp_C: warm\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertIsNone(config.getfloat('AC', 'Trip_Temp_C', fallback=None))
+        self.assertEqual(warning.call_count, 2)
+
+    def test_loader_removes_an_interpolation_breaking_trip_temperature(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\nTrip_Temp_C: 95%\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertIsNone(config.getfloat('AC', 'Trip_Temp_C', fallback=None))
+        warning.assert_called_once()
+
+    def test_loader_falls_back_to_a_valid_default_trip_temperature(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nTrip_Temp_C: 90\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\nTrip_Temp_C: warm\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertEqual(config.getfloat('AC', 'Trip_Temp_C'), 90.0)
+        warning.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -374,6 +374,125 @@ class ConfigValidationTests(unittest.TestCase):
         self.assertEqual(config.getfloat('AC', 'Trip_Temp_C'), 90.0)
         warning.assert_called_once()
 
+    def test_loader_removes_malformed_power_limits_inherited_from_default(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nPL1_Tdp_W: hot\nPL2_Tdp_W: nan\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertIsNone(config.getfloat('AC', 'PL1_Tdp_W', fallback=None))
+        self.assertIsNone(config.getfloat('AC', 'PL2_Tdp_W', fallback=None))
+        messages = [call.args[0] for call in warning.call_args_list]
+        self.assertEqual(len(messages), 2)
+        self.assertTrue(all('[DEFAULT]' in message for message in messages))
+
+    def test_loader_shadows_malformed_undervolt_planes_inherited_from_default(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nCORE: deep\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n[UNDERVOLT.AC]\nCACHE: -50\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertEqual(config.getfloat('UNDERVOLT.AC', 'CORE', fallback=0.0), 0.0)
+        self.assertEqual(config.getfloat('UNDERVOLT.AC', 'CACHE'), -50)
+        messages = [call.args[0] for call in warning.call_args_list]
+        self.assertTrue(any('[DEFAULT]' in message for message in messages))
+
+    def test_loader_shadows_malformed_iccmax_planes_inherited_from_default(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nCORE: lots\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n[ICCMAX.AC]\nCACHE: 100\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertEqual(config.getfloat('ICCMAX.AC', 'CORE'), 0.0)
+        messages = [call.args[0] for call in warning.call_args_list]
+        self.assertTrue(any('[DEFAULT]' in message for message in messages))
+
+        with mock.patch.object(throttled, 'writemsr') as writemsr:
+            throttled.set_icc_max(config, source='AC')
+
+        writemsr.assert_called_once()
+
+    def test_loader_vets_the_synthesized_undervolt_profile_against_default_planes(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nGPU: bogus\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n[UNDERVOLT.AC]\nGPU: -50\n'
+        )
+
+        with mock.patch.object(throttled, 'warning'):
+            config = throttled.load_config()
+
+        self.assertEqual(config.getfloat('UNDERVOLT.AC', 'GPU'), -50)
+        self.assertEqual(config.getfloat('UNDERVOLT.BATTERY', 'GPU'), 0)
+
+    def test_loader_lets_the_synthesized_undervolt_profile_inherit_valid_defaults(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nCORE: -100\nCACHE: -100\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n'
+            '[UNDERVOLT.AC]\nGPU: -50\n'
+        )
+
+        with mock.patch.object(throttled, 'warning'):
+            config = throttled.load_config()
+
+        self.assertEqual(config.getfloat('UNDERVOLT.BATTERY', 'CORE'), -100)
+        self.assertEqual(config.getfloat('UNDERVOLT.BATTERY', 'CACHE'), -100)
+        self.assertEqual(config.getfloat('UNDERVOLT.BATTERY', 'GPU'), 0)
+        self.assertEqual(config.getfloat('UNDERVOLT.AC', 'CORE'), -100)
+
+    def test_loader_removes_masked_power_limits_from_both_layers(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nPL1_Tdp_W: 45%\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\nPL1_Tdp_W: hot\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertIsNone(config.getfloat('AC', 'PL1_Tdp_W', fallback=None))
+        messages = [call.args[0] for call in warning.call_args_list]
+        self.assertEqual(len(messages), 2)
+        self.assertIn('[AC]', messages[0])
+        self.assertIn('[DEFAULT]', messages[1])
+
+    def test_loader_shadows_a_default_plane_masked_by_a_malformed_own_value(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nCORE: junk\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n[UNDERVOLT.AC]\nCORE: zzz\n'
+        )
+
+        with mock.patch.object(throttled, 'warning') as warning:
+            config = throttled.load_config()
+
+        self.assertEqual(config.getfloat('UNDERVOLT.AC', 'CORE'), 0.0)
+        self.assertEqual(config.getfloat('UNDERVOLT.BATTERY', 'CORE'), 0.0)
+        messages = [call.args[0] for call in warning.call_args_list]
+        self.assertTrue(any('[UNDERVOLT.AC]' in message for message in messages))
+        self.assertTrue(any('[DEFAULT]' in message for message in messages))
+
+    def test_loader_keeps_a_shared_default_undervolt_rejected_by_iccmax(self):
+        throttled = load_throttled()
+        throttled.args.config = self.write_config(
+            '[DEFAULT]\nCORE: -100\nCACHE: -100\n[GENERAL]\nEnabled: True\n[AC]\nUpdate_Rate_s: 5\n'
+            '[UNDERVOLT]\nGPU: -50\n[ICCMAX.AC]\nGPU: 100\n'
+        )
+
+        with mock.patch.object(throttled, 'warning'):
+            config = throttled.load_config()
+
+        self.assertEqual(config.getfloat('UNDERVOLT', 'CORE'), -100)
+        self.assertEqual(config.getfloat('UNDERVOLT', 'CACHE'), -100)
+        self.assertEqual(config.getfloat('ICCMAX.AC', 'CORE'), 0.0)
+        self.assertEqual(config.getfloat('ICCMAX.AC', 'GPU'), 100)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/throttled.py
+++ b/throttled.py
@@ -823,6 +823,14 @@ def set_icc_max(config, source=None):
             pass
 
 
+def _remove_config_option(config, section, option):
+    """Drop option from the layer holding it and return that layer's name."""
+    if config.remove_option(section, option):
+        return section
+    config.remove_option(config.default_section, option)
+    return config.default_section
+
+
 def load_config():
     """Parse the config file, validating and clamping out-of-range values."""
     config = configparser.ConfigParser()
@@ -835,23 +843,26 @@ def load_config():
     # config values sanity check
     for power_source in power_profiles:
         for option in ('Update_Rate_s', 'PL1_Tdp_W', 'PL1_Duration_s', 'PL2_Tdp_W', 'PL2_Duration_S'):
-            try:
-                value = config.getfloat(power_source, option, fallback=None)
-                if value is not None and not math.isfinite(value):
+            value = None
+            # a malformed profile value may mask a second malformed value inherited from [DEFAULT]
+            for _ in range(2):
+                try:
+                    value = config.getfloat(power_source, option, fallback=None)
+                    if value is None or math.isfinite(value):
+                        break
                     raise ValueError(value)
-            except ValueError:
-                if option == 'Update_Rate_s':
-                    fatal(f'The mandatory "Update_Rate_s" parameter in [{power_source:s}] must be a finite number.')
-                warning(f'Invalid "{option:s}" value in [{power_source:s}]; leaving it disabled.', oneshot=False)
-                config.remove_option(power_source, option)
-                value = None
+                except (ValueError, configparser.InterpolationError):
+                    value = None
+                    section = _remove_config_option(config, power_source, option)
+                    if option == 'Update_Rate_s':
+                        fatal(f'The mandatory "Update_Rate_s" parameter in [{section:s}] must be a finite number.')
+                    warning(f'Invalid "{option:s}" value in [{section:s}]: ignoring it.', oneshot=False)
             if value is not None:
                 config.set(power_source, option, str(max(0.001, value)))
             elif option == 'Update_Rate_s':
                 fatal(f'The mandatory "Update_Rate_s" parameter is missing in the [{power_source:s}] profile.')
 
         trip_temp = None
-        # a malformed profile value may mask a second malformed value inherited from [DEFAULT]
         for _ in range(2):
             try:
                 trip_temp = config.getfloat(power_source, 'Trip_Temp_C', fallback=None)
@@ -860,12 +871,7 @@ def load_config():
                 raise ValueError(trip_temp)
             except (ValueError, configparser.InterpolationError):
                 trip_temp = None
-                if config.remove_option(power_source, 'Trip_Temp_C'):
-                    section = power_source
-                else:
-                    # the value is inherited from [DEFAULT]: drop it there or it survives the removal
-                    section = config.default_section
-                    config.remove_option(section, 'Trip_Temp_C')
+                section = _remove_config_option(config, power_source, 'Trip_Temp_C')
                 warning(f'Invalid "Trip_Temp_C" value in [{section:s}]: ignoring it.', oneshot=False)
         if trip_temp is not None:
             valid_trip_temp = min(TRIP_TEMP_RANGE[1], max(TRIP_TEMP_RANGE[0], trip_temp))
@@ -875,34 +881,43 @@ def load_config():
                     f'[!] Overriding invalid "Trip_Temp_C" value in "{power_source:s}": {trip_temp:.1f} -> {valid_trip_temp:.1f}'
                 )
 
-    # the mailbox field is signed 11-bit: reject anything below -1000 mV instead of wrapping it positive
-    for key in UNDERVOLT_KEYS:
-        for plane in VOLTAGE_PLANES:
-            if key in config:
-                try:
-                    value = config.getfloat(key, plane, fallback=0.0)
-                    if not math.isfinite(value):
-                        raise ValueError(f'Undervolt offset must be finite, got {value!r}.')
-                    if value > 0:
-                        config.set(key, plane, '0')
-                        log(
-                            f'[!] Overriding invalid "{key:s}" value in "{plane:s}" voltage plane: {value:.0f} -> 0'
-                        )
-                    else:
-                        _undervolt_offset_to_ticks(value)
-                except ValueError as e:
-                    warning(f'Invalid value for {plane:s} in {key:s}: {e}', oneshot=False)
-                    config.remove_option(key, plane)
-
     # handle the case where only one of UNDERVOLT.AC, UNDERVOLT.BATTERY keys exists
-    # by forcing the other key to all zeros (ie. no undervolt)
+    # by forcing the other key to all zeros (ie. no undervolt); synthesizing it
+    # before the vetting below puts its [DEFAULT]-inherited planes through it too
     if any(key in config for key in UNDERVOLT_KEYS[1:]):
         for key in UNDERVOLT_KEYS[1:]:
             if key not in config:
                 config.add_section(key)
+
+    # the mailbox field is signed 11-bit: reject anything below -1000 mV instead of wrapping it positive
+    for key in UNDERVOLT_KEYS:
+        for plane in VOLTAGE_PLANES:
+            if key in config:
+                for _ in range(2):
+                    try:
+                        value = config.getfloat(key, plane, fallback=0.0)
+                        if not math.isfinite(value):
+                            raise ValueError(f'Undervolt offset must be finite, got {value!r}.')
+                        if value > 0:
+                            config.set(key, plane, '0')
+                            log(
+                                f'[!] Overriding invalid "{key:s}" value in "{plane:s}" voltage plane: {value:.0f} -> 0'
+                            )
+                        else:
+                            _undervolt_offset_to_ticks(value)
+                        break
+                    except (ValueError, configparser.InterpolationError) as e:
+                        section = key if config.remove_option(key, plane) else config.default_section
+                        warning(f'Invalid value for {plane:s} in [{section:s}]: {e}', oneshot=False)
+                        if section == config.default_section:
+                            # the plane names are shared with ICCMAX: shadow the inherited value, never touch [DEFAULT]
+                            config.set(key, plane, '0')
+                            break
+
+    for key in UNDERVOLT_KEYS[1:]:
+        if key in config:
             for plane in VOLTAGE_PLANES:
-                value = config.getfloat(key, plane, fallback=0.0)
-                config.set(key, plane, str(value))
+                config.set(key, plane, str(config.getfloat(key, plane, fallback=0.0)))
 
     # Check for CORE/CACHE values mismatch
     for key in UNDERVOLT_KEYS:
@@ -923,15 +938,21 @@ def load_config():
                 warning(f'Unknown IccMax plane "{option:s}" in [{key:s}]: ignoring it.', oneshot=False)
         for plane in CURRENT_PLANES:
             if key in config:
-                try:
-                    value = config.getfloat(key, plane)
-                    _icc_max_to_field(value)
-                    iccmax_enabled = True
-                except ValueError as e:
-                    warning(f'Invalid value for {plane:s} in {key:s}: {e}', oneshot=False)
-                    config.remove_option(key, plane)
-                except configparser.NoOptionError:
-                    pass
+                for _ in range(2):
+                    try:
+                        value = config.getfloat(key, plane)
+                        _icc_max_to_field(value)
+                        iccmax_enabled = True
+                        break
+                    except (ValueError, configparser.InterpolationError) as e:
+                        section = key if config.remove_option(key, plane) else config.default_section
+                        warning(f'Invalid value for {plane:s} in [{section:s}]: {e}', oneshot=False)
+                        if section == config.default_section:
+                            # the plane names are shared with UNDERVOLT: shadow the inherited value, never touch [DEFAULT]
+                            config.set(key, plane, '0')
+                            break
+                    except configparser.NoOptionError:
+                        break
     if iccmax_enabled:
         warning('Warning! Raising IccMax above design limits can damage your system!')
 

--- a/throttled.py
+++ b/throttled.py
@@ -850,7 +850,23 @@ def load_config():
             elif option == 'Update_Rate_s':
                 fatal(f'The mandatory "Update_Rate_s" parameter is missing in the [{power_source:s}] profile.')
 
-        trip_temp = config.getfloat(power_source, 'Trip_Temp_C', fallback=None)
+        trip_temp = None
+        # a malformed profile value may mask a second malformed value inherited from [DEFAULT]
+        for _ in range(2):
+            try:
+                trip_temp = config.getfloat(power_source, 'Trip_Temp_C', fallback=None)
+                if trip_temp is None or math.isfinite(trip_temp):
+                    break
+                raise ValueError(trip_temp)
+            except (ValueError, configparser.InterpolationError):
+                trip_temp = None
+                if config.remove_option(power_source, 'Trip_Temp_C'):
+                    section = power_source
+                else:
+                    # the value is inherited from [DEFAULT]: drop it there or it survives the removal
+                    section = config.default_section
+                    config.remove_option(section, 'Trip_Temp_C')
+                warning(f'Invalid "Trip_Temp_C" value in [{section:s}]: ignoring it.', oneshot=False)
         if trip_temp is not None:
             valid_trip_temp = min(TRIP_TEMP_RANGE[1], max(TRIP_TEMP_RANGE[0], trip_temp))
             if trip_temp != valid_trip_temp:


### PR DESCRIPTION
Stacked on #410 (its commit is this branch's parent — review the last commit only; it generalizes #410's layered removal, so it does not apply to master standalone).

**What crashes today** (each reproduced on master + #410, each covered by a regression test that fails on the parent):

- a malformed `PL1_Tdp_W`/`PL2_Tdp_W`/duration in `[DEFAULT]` survives `remove_option()` on the profile section and kills `calc_reg_values()`;
- a malformed undervolt plane in `[DEFAULT]` kills `load_config()` itself, at the unguarded `getfloat` in the block that synthesizes the missing `UNDERVOLT.*` sibling — also reachable when every declared `UNDERVOLT.*` section masks the bad default with a valid own value;
- a malformed IccMax plane in `[DEFAULT]` survives and kills `set_icc_max()`;
- `should_listen_for_resume()` dies on both plane classes before the D-Bus handlers exist.

**Design.** The power-limit options have names only the profiles read, so they reuse #410's layered removal (`_remove_config_option()`): drop the layer the bad value lives in, re-check, let a valid default take over. The plane names are shared between the UNDERVOLT (mV, <= 0) and ICCMAX (A, > 0) namespaces, so there a rejected inherited value is never deleted from `[DEFAULT]` — a valid shared undervolt default is by construction an invalid IccMax, and deleting it would silently zero the user's undervolt. It is shadowed with an explicit in-section `0` instead ("not configured" for both consumers, neutral for `should_listen_for_resume()`), and `[DEFAULT]` is left untouched. Values in the section proper are still genuinely removed, as the existing tests pin.

The missing `UNDERVOLT.*` sibling is now synthesized before the vetting pass, so its inherited planes go through the same validation instead of the raw read — behavior on valid configs is unchanged (the sibling keeps inheriting valid `[DEFAULT]` planes, as before).

**Visible behavior notes:** warnings name the layer the bad value lives in and bracket the section; the power-limit warning says ": ignoring it." (a valid default can take over, same as the trip-temp path); a malformed `Update_Rate_s` still exits fatally on first sight, now naming the right layer; an inherited value now goes through the same clamp path as an own value.

**Scope:** this covers the numeric loops `load_config()` validates. Non-numeric options (`Enabled`, `HWP_Mode`, `Autoreload`, `cTDP`) are validated nowhere and fail identically with or without `[DEFAULT]` — pre-existing and orthogonal, deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
